### PR TITLE
FixFox: `username` covered by the node shape

### DIFF
--- a/kmua/common/waifu.py
+++ b/kmua/common/waifu.py
@@ -113,6 +113,8 @@ def render_waifu_graph(
         graph_attr={
             "dpi": str(dpi),
             "beautify": "true",
+            "compound": "true",
+            "ranksep": "1",
         },
         format="webp",
     )
@@ -121,6 +123,7 @@ def render_waifu_graph(
 
     try:
         # Create nodes
+        has_avatar = set()
         for user_id, info in user_info.items():
             username = info.get("username")
             username = (
@@ -129,6 +132,7 @@ def render_waifu_graph(
             if not info.get("avatar"):
                 dot.node(str(user_id), label=username)
                 continue
+            has_avatar.add(user_id)
             avatar = info["avatar"]
             avatar_path = os.path.join(tempdir, f"{user_id}_avatar.png")
             with open(avatar_path, "wb") as avatar_file:
@@ -152,7 +156,11 @@ def render_waifu_graph(
 
         # Create edges
         for user_id, waifu_id in relationships:
-            dot.edge(str(user_id), str(waifu_id))
+            dot.edge(
+                str(user_id), str(waifu_id),
+                lhead=f"cluster_{waifu_id}" if waifu_id in has_avatar else None,
+                ltail=f"cluster_{user_id}" if user_id in has_avatar else None
+            )
 
         return dot.pipe()
 


### PR DESCRIPTION
Edge between `cluster`s if has `avatar`

### Before
![before](https://github.com/krau/kmua-bot/assets/26835631/2ab4d51c-9b98-491d-a4fd-0f1ead72a6a8)

### After
![after](https://github.com/krau/kmua-bot/assets/26835631/6672dea6-85b8-4ea4-9429-004e990821ec)

### Test code
```bash
convert -resize 20x20 avatar.jpg out.jpg
```

```python
with open('./out.jpg', 'rb') as ftrb:
    avatar = ftrb.read()
    relationships = [(1, 2), (3, 4), (5, 6), (7, 8)]
    user_info = {
        1: {'username': 'hello', 'avatar': avatar},
        2: {'username': 'world', 'avatar': avatar},
        3: {'username': 'a', 'avatar': avatar},
        4: {'username': 'b'},
        5: {'username': 'a'},
        6: {'username': 'b', 'avatar': avatar},
        7: {'username': 'a'},
        8: {'username': 'b'},
    }
    p = render_waifu_graph(relationships, user_info)
    with open('out.webp', 'wb') as ftwb:
        ftwb.write(p)
```