### PR TITLE
FixFor: broken `arrowhead` for pairs

### DIFF
--- a/kmua/common/waifu.py
+++ b/kmua/common/waifu.py
@@ -115,6 +115,7 @@ def render_waifu_graph(
             "beautify": "true",
             "compound": "true",
             "ranksep": "1",
+            "splines": "ortho",
         },
         format="webp",
     )
@@ -158,8 +159,8 @@ def render_waifu_graph(
         for user_id, waifu_id in relationships:
             dot.edge(
                 str(user_id), str(waifu_id),
-                lhead=f"cluster_{waifu_id}" if waifu_id in has_avatar else None,
-                ltail=f"cluster_{user_id}" if user_id in has_avatar else None
+                lhead=f"cluster_{waifu_id}" if waifu_id in has_avatar else "",
+                ltail=f"cluster_{user_id}" if user_id in has_avatar else "",
             )
 
         return dot.pipe()


### PR DESCRIPTION
sorry, `splines` is not `curve` (sexy) anymore

### Before
![pair_before](https://github.com/krau/kmua-bot/assets/26835631/596f25c4-2163-43d4-8c7c-d372c94ec322)


### After
![pair_after](https://github.com/krau/kmua-bot/assets/26835631/c3abc58d-9863-439c-a25d-7e830d0ca197)
