### PR TITLE
随机语录时使用数据库内的语录数据发送，而不是转发消息

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ demo: [@kmuav2bot](https://t.me/kmuav2bot)
                 </a>
             </td>
             <td align="center">
+                <a href="https://github.com/tjsky">
+                    <img src="https://avatars.githubusercontent.com/u/7272911?v=4" width="100;" alt="tjsky"/>
+                    <br />
+                    <sub><b>去年夏天</b></sub>
+                </a>
+            </td>
+            <td align="center">
                 <a href="https://github.com/NyanWhite">
                     <img src="https://avatars.githubusercontent.com/u/51278093?v=4" width="100;" alt="NyanWhite"/>
                     <br />
@@ -43,13 +50,6 @@ demo: [@kmuav2bot](https://t.me/kmuav2bot)
                     <img src="https://avatars.githubusercontent.com/u/26835631?v=4" width="100;" alt="ames0k0"/>
                     <br />
                     <sub><b>YóUnǎi</b></sub>
-                </a>
-            </td>
-            <td align="center">
-                <a href="https://github.com/tjsky">
-                    <img src="https://avatars.githubusercontent.com/u/7272911?v=4" width="100;" alt="tjsky"/>
-                    <br />
-                    <sub><b>去年夏天</b></sub>
                 </a>
             </td>
             <td align="center">

--- a/kmua/callbacks/quote.py
+++ b/kmua/callbacks/quote.py
@@ -36,15 +36,15 @@ async def quote(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if context.args and context.args[0] != "nopin":
         return
     if not message.reply_to_message:
-        await message.reply_text("请回复一条消息")
+        await message.reply_text("请回复一条消息￣□￣")
         return
     if message.is_topic_message:
-        await message.reply_text("暂不支持在主话题外使用此功能")
+        await message.reply_text("暂不支持在主话题外使用此功能呢")
         return
     quote_message = message.reply_to_message
     quote_user = common.get_message_origin(quote_message)
     if not quote_user:
-        await message.reply_text("不知道这条消息是谁发的呢...")
+        await message.reply_text("喵不知道这条消息是谁发的呢...")
         return
     qer_user = message.sender_chat or user
     dao.add_user(quote_user)
@@ -63,10 +63,10 @@ async def quote(update: Update, context: ContextTypes.DEFAULT_TYPE):
             chat_id=chat.id,
         )
         return
-    text = ["好\\!", "让我康康是谁在说怪话\\!", "名入册焉"]
+    text = ["好\\!", "让我康康是谁在说怪话\\!", "名入册焉\\!", "好，我记住你了\\!"]
     choice_text = random.choice(text)
     if not quote_message.text or len(quote_message.text) > 200:
-        choice_text += "\n_非文本消息或文本过长不能生成图片哦_"
+        choice_text += "\n_请不要插入奇怪或长长的东西啦>﹏<_\n¯¯非文本消息或文本过长是无法生成图片哦¯¯"
     tasks = [
         quote_message.reply_text(text=choice_text, parse_mode=ParseMode.MARKDOWN_V2),
         _generate_and_send_quote_img(update, context, quote_message, quote_user),

--- a/kmua/callbacks/quote.py
+++ b/kmua/callbacks/quote.py
@@ -66,7 +66,7 @@ async def quote(update: Update, context: ContextTypes.DEFAULT_TYPE):
     text = ["好\\!", "让我康康是谁在说怪话\\!", "名入册焉\\!", "好，我记住你了\\!"]
     choice_text = random.choice(text)
     if not quote_message.text or len(quote_message.text) > 200:
-        choice_text += "\n_请不要插入奇怪或长长的东西啦>﹏<_\n¯¯非文本消息或文本过长是无法生成图片哦¯¯"
+        choice_text += "\n_请不要插入奇怪或长长的东西啦\\>﹏\\<_\n¯¯非文本消息或文本过长是无法生成图片哦¯¯"
     tasks = [
         quote_message.reply_text(text=choice_text, parse_mode=ParseMode.MARKDOWN_V2),
         _generate_and_send_quote_img(update, context, quote_message, quote_user),

--- a/kmua/callbacks/quote.py
+++ b/kmua/callbacks/quote.py
@@ -66,7 +66,7 @@ async def quote(update: Update, context: ContextTypes.DEFAULT_TYPE):
     text = ["好\\!", "让我康康是谁在说怪话\\!", "名入册焉\\!", "好，我记住你了\\!"]
     choice_text = random.choice(text)
     if not quote_message.text or len(quote_message.text) > 200:
-        choice_text += "\n_请不要插入奇怪或长长的东西啦\\>﹏\\<_\n¯¯非文本消息或文本过长是无法生成图片哦¯¯"
+        choice_text += "\n_请不要插入奇怪或长长的东西啦 \\>﹏\\<_\n~~非文本消息或文本过长不能生成图片的哦~~"
     tasks = [
         quote_message.reply_text(text=choice_text, parse_mode=ParseMode.MARKDOWN_V2),
         _generate_and_send_quote_img(update, context, quote_message, quote_user),

--- a/kmua/callbacks/quote.py
+++ b/kmua/callbacks/quote.py
@@ -199,38 +199,45 @@ async def random_quote(update: Update, _: ContextTypes.DEFAULT_TYPE):
     user = update.effective_user
     message = update.effective_message
     logger.trace(f"[{chat.title}]({user.name}) <random_quote>")
-    
     pb = dao.get_chat_quote_probability(chat)
     flag = common.random_unit(pb)
     if message.text is not None:
         if message.text.startswith("/qrand") and pb >= 0:
             flag = True
+            
     if not flag:
         return
     
     quote = dao.get_chat_random_quote(chat)
     if not quote:
         return
-    
+        
     try:
-        text = f"{escape_markdown(quote.text, 2)}\n\n" if quote.text else ""
-        text += f"[原始消息链接]({escape_markdown(quote.link, 2)})"
+        keyboard = [
+            [InlineKeyboardButton(
+                "Source", 
+                url=quote.link  
+            )]
+        ]
+        reply_markup = InlineKeyboardMarkup(keyboard)
         
         if quote.img:
             sent_message = await chat.send_photo(
                 photo=quote.img,
-                caption=text,
-                parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=reply_markup,
                 message_thread_id=update.effective_message.message_thread_id
             )
+            
         else:
+            text = escape_markdown(quote.text, 2) if quote.text else "完了，忘了要说什么了"
             sent_message = await chat.send_message(
                 text=text,
                 parse_mode=ParseMode.MARKDOWN_V2,
+                reply_markup=reply_markup,
                 disable_web_page_preview=True,
                 message_thread_id=update.effective_message.message_thread_id
             )
-        
+
         logger.info(f"Bot sent quote: {sent_message.text or 'IMAGE'}")
 
     except Exception as e:

--- a/kmua/callbacks/quote.py
+++ b/kmua/callbacks/quote.py
@@ -195,15 +195,11 @@ async def _unpin_messsage(
 
 
 async def random_quote(update: Update, _: ContextTypes.DEFAULT_TYPE):
-    """
-    随机发送一条语录
-    此功能不会在私聊中被调用, 已由 filters 过滤
-    私聊中的消息将直接由 keyword_reply_handler 处理
-    """
     chat = update.effective_chat
     user = update.effective_user
     message = update.effective_message
     logger.trace(f"[{chat.title}]({user.name}) <random_quote>")
+    
     pb = dao.get_chat_quote_probability(chat)
     flag = common.random_unit(pb)
     if message.text is not None:
@@ -211,16 +207,32 @@ async def random_quote(update: Update, _: ContextTypes.DEFAULT_TYPE):
             flag = True
     if not flag:
         return
+    
     quote = dao.get_chat_random_quote(chat)
     if not quote:
         return
+    
     try:
-        sent_message = await chat.forward_to(
-            chat_id=chat.id,
-            message_id=quote.message_id,
-            message_thread_id=update.effective_message.message_thread_id,
-        )
-        logger.info(f"Bot forward message: {sent_message.text}")
+        text = f"{escape_markdown(quote.text, 2)}\n\n" if quote.text else ""
+        text += f"[原始消息链接]({escape_markdown(quote.link, 2)})"
+        
+        if quote.img:
+            sent_message = await chat.send_photo(
+                photo=quote.img,
+                caption=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                message_thread_id=update.effective_message.message_thread_id
+            )
+        else:
+            sent_message = await chat.send_message(
+                text=text,
+                parse_mode=ParseMode.MARKDOWN_V2,
+                disable_web_page_preview=True,
+                message_thread_id=update.effective_message.message_thread_id
+            )
+        
+        logger.info(f"Bot sent quote: {sent_message.text or 'IMAGE'}")
+
     except Exception as e:
         logger.warning(f"{e.__class__.__name__}: {e}")
 

--- a/kmua/callbacks/quote.py
+++ b/kmua/callbacks/quote.py
@@ -195,6 +195,11 @@ async def _unpin_messsage(
 
 
 async def random_quote(update: Update, _: ContextTypes.DEFAULT_TYPE):
+    """
+    随机发送一条语录
+    此功能不会在私聊中被调用, 已由 filters 过滤
+    私聊中的消息将直接由 keyword_reply_handler 处理
+    """
     chat = update.effective_chat
     user = update.effective_user
     message = update.effective_message


### PR DESCRIPTION
就像内联状态下那样，原有的随机模式无法在开启禁止转发保存的群组内发送随机语录。

PS：我没测试概率随机发送部分，不过按说我也没动这部分逻辑，应该没问题。