### PR TITLE
修复 IP查询会暴漏bot自身IP的问题

### DIFF
--- a/kmua/plugins/tools/ip.py
+++ b/kmua/plugins/tools/ip.py
@@ -1,4 +1,5 @@
 import contextlib
+import re
 from urllib.parse import urlparse
 
 import httpx
@@ -38,6 +39,10 @@ async def ipinfo(client: Client, message: Message):
 
     if not ip:
         await message.reply_text(i18n.t("bot.msg.ip.no_ip_provided", locale=lang))
+        return
+
+    if not re.match(r"^[a-zA-Z0-9.:-]+$", ip):
+        await message.reply_text(i18n.t("bot.msg.ip.no_ip_provided", locale=lang)) 
         return
 
     sent_message = await message.reply_text(


### PR DESCRIPTION
## 漏洞
当用户用 `/ip` 命令查 IP 的时，如果输入`/ip /`
代码里 `urlparse` 出来的 `ip` 变量最后会变成一个单纯的斜杠 `"/"`。
接口`ip-api.com` 那边就会把它当成空查询，返回查询发起者自己的IP，运行bot的机器的IP就被泄露了。


## 修复

加了个格式校验`re.match(r"^[a-zA-Z0-9.:-]+$", ip)`
