### PR TITLE
fix(agent): 修复事件循环阻塞导致的无响应卡死

### DIFF
--- a/kmua/__main__.py
+++ b/kmua/__main__.py
@@ -17,6 +17,7 @@ from kmua.config import app_config
 from kmua.database import db
 from kmua.health import start_health_server, stop_health_server
 from kmua.logger import logger
+from kmua.loop_monitor import LoopLagMonitor
 
 
 def _get_commands_hash(commands_dict: dict[str, list[BotCommand]]) -> str:
@@ -245,6 +246,16 @@ async def stop_bot(client: Client = client):
 async def main():
     await db.init_db()
 
+    # Start event-loop lag monitor (helps diagnose freezes: logs a warning and
+    # dumps running task stacks whenever the loop is blocked beyond a threshold).
+    loop_monitor = None
+    if app_config.loop_monitor_enabled:
+        loop_monitor = LoopLagMonitor(
+            interval=app_config.loop_monitor_interval,
+            warn_threshold=app_config.loop_monitor_threshold,
+        )
+        loop_monitor.start()
+
     # Start health check server
     health_runner = None
     if app_config.health_check_enabled:
@@ -260,6 +271,9 @@ async def main():
     # Stop health check server
     if health_runner:
         await stop_health_server(health_runner)
+
+    if loop_monitor:
+        await loop_monitor.stop()
 
 
 if __name__ == "__main__":

--- a/kmua/bot/client.py
+++ b/kmua/bot/client.py
@@ -42,5 +42,5 @@ client = Client(
     plugins=_build_plugins_config(),
     ipv6=app_config.use_ipv6,
     sleep_threshold=300,
-    max_concurrent_transmissions=min(32, cpu_count() or 0 + 4),
+    max_concurrent_transmissions=min(32, (cpu_count() or 0) + 4),
 )

--- a/kmua/common/utils.py
+++ b/kmua/common/utils.py
@@ -14,6 +14,36 @@ MAX_WEBM_SIZE = 10 * 1024 * 1024
 # WEBM 处理超时 (秒)
 WEBM_PROCESS_TIMEOUT = 10
 
+# Strong references to background tasks so they are not garbage-collected
+# mid-flight (asyncio only keeps weak references to tasks).
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _on_task_done(task: asyncio.Task) -> None:
+    _background_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.opt(exception=exc).error(
+            f"Background task {task.get_name()!r} raised an unhandled exception: "
+            f"{exc.__class__.__name__} - {exc}"
+        )
+
+
+def spawn(coro, *, name: str | None = None) -> asyncio.Task:
+    """Schedule a coroutine as a background task safely.
+
+    Unlike a bare ``asyncio.create_task``:
+    - keeps a strong reference until the task finishes (prevents the task from
+      being silently garbage-collected before completion), and
+    - logs any unhandled exception instead of swallowing it.
+    """
+    task = asyncio.create_task(coro, name=name)
+    _background_tasks.add(task)
+    task.add_done_callback(_on_task_done)
+    return task
+
 
 def get_msg_link(message: pyrogram.types.Message) -> str:
     try:

--- a/kmua/config/__init__.py
+++ b/kmua/config/__init__.py
@@ -43,6 +43,15 @@ class _AppConfig(pydantic.BaseModel):
     health_check_host: str = "localhost"
     health_check_port: int = 8180
 
+    # event loop lag monitor: detects when the single asyncio event loop is
+    # blocked (the root cause of "bot freezes, no logs, no response"). When the
+    # measured scheduling lag exceeds the threshold, a warning is logged together
+    # with stack traces of the currently running tasks so the culprit await/call
+    # can be identified.
+    loop_monitor_enabled: bool = True
+    loop_monitor_interval: float = 1.0  # how often to sample lag (seconds)
+    loop_monitor_threshold: float = 1.0  # warn when lag exceeds this (seconds)
+
     # external services
     redis: bool = False
     redis_endpoint: str = "localhost"
@@ -145,6 +154,12 @@ class _AppConfig(pydantic.BaseModel):
     agent_model_timeout: int = 0  # Main model timeout (0 = no timeout)
     agent_small_model_timeout: int = 10  # Small model timeout for quick tasks
     agent_download_timeout: int = 30  # Download media timeout (0 = no timeout)
+    # Overall wall-clock timeout for a single agent run (the whole iter loop,
+    # including all tool calls and streaming). Prevents a stuck model/tool call
+    # from blocking a dispatcher worker indefinitely. 0 = no timeout.
+    agent_run_timeout: int = 180
+    # Timeout for a single webfetch (_fetch_http via crawl4ai). 0 = no timeout.
+    agent_webfetch_timeout: int = 45
     # Image generation/editing: "provider/model" spec.
     # Generation client is disabled when unset.
     agent_image_gen_model: str | None = None

--- a/kmua/loop_monitor.py
+++ b/kmua/loop_monitor.py
@@ -1,0 +1,114 @@
+"""Event-loop lag monitor.
+
+A small background watchdog that measures asyncio scheduling latency. When the
+event loop is blocked (by a synchronous/CPU-bound call, a stuck ``await``, or a
+handler that never yields), this monitor will — once the loop runs again — see
+that far more time elapsed than expected and emit a warning together with a dump
+of the stacks of all currently-running tasks.
+
+This is the fastest way to pinpoint *where* a freeze happens: the next time the
+bot hangs, the logs will show which coroutine was on the stack.
+"""
+
+import asyncio
+
+from kmua.logger import logger
+
+
+class LoopLagMonitor:
+    def __init__(
+        self,
+        interval: float = 1.0,
+        warn_threshold: float = 1.0,
+        max_stacks: int = 10,
+    ) -> None:
+        """
+        Args:
+            interval: How often (seconds) the watchdog wakes up to measure lag.
+            warn_threshold: Extra delay (seconds) beyond ``interval`` that counts
+                as a stall worth reporting.
+            max_stacks: Maximum number of task stacks to dump per stall.
+        """
+        self.interval = interval
+        self.warn_threshold = warn_threshold
+        self.max_stacks = max_stacks
+        self._task: asyncio.Task | None = None
+        self._stop = False
+
+    async def _loop(self) -> None:
+        loop = asyncio.get_running_loop()
+        while not self._stop:
+            start = loop.time()
+            try:
+                await asyncio.sleep(self.interval)
+            except asyncio.CancelledError:
+                break
+            elapsed = loop.time() - start
+            lag = elapsed - self.interval
+            if lag >= self.warn_threshold:
+                logger.warning(
+                    f"Event loop stalled for ~{lag:.2f}s "
+                    f"(expected {self.interval:.2f}s sleep, took {elapsed:.2f}s). "
+                    f"Dumping running task stacks:"
+                )
+                self._dump_task_stacks()
+
+    def _dump_task_stacks(self) -> None:
+        try:
+            current = asyncio.current_task()
+            tasks = [
+                t
+                for t in asyncio.all_tasks()
+                if t is not current and not t.done()
+            ]
+        except Exception as e:
+            logger.error(f"loop_monitor: failed to collect tasks: {e}")
+            return
+
+        dumped = 0
+        for task in tasks:
+            if dumped >= self.max_stacks:
+                logger.warning(
+                    f"loop_monitor: ... and {len(tasks) - dumped} more tasks"
+                )
+                break
+            try:
+                stack = task.get_stack(limit=8)
+                if not stack:
+                    continue
+                frames = []
+                for frame in stack:
+                    code = frame.f_code
+                    frames.append(
+                        f"{code.co_filename}:{frame.f_lineno} in {code.co_name}"
+                    )
+                stack_text = "\n    ".join(frames)
+                logger.warning(
+                    f"loop_monitor: task {task.get_name()!r} stack:\n    {stack_text}"
+                )
+                dumped += 1
+            except Exception as e:
+                logger.error(f"loop_monitor: failed to dump task stack: {e}")
+
+    def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._stop = False
+        self._task = asyncio.create_task(self._loop(), name="loop-lag-monitor")
+        logger.info(
+            f"Event-loop lag monitor started "
+            f"(interval={self.interval}s, warn_threshold={self.warn_threshold}s)"
+        )
+
+    async def stop(self) -> None:
+        self._stop = True
+        if self._task and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        logger.info("Event-loop lag monitor stopped")
+
+
+__all__ = ["LoopLagMonitor"]

--- a/kmua/plugins/agent/agent.py
+++ b/kmua/plugins/agent/agent.py
@@ -10,6 +10,7 @@ from pydantic_ai import (
     RunContext,
     Tool,
 )
+from pydantic_ai.capabilities import ProcessHistory
 from pydantic_ai.common_tools.duckduckgo import DuckDuckGoSearchTool
 from pyrogram import filters
 from pyrogram.client import Client as PyrogramClient
@@ -44,16 +45,29 @@ struct_model = None
 summary_agent = None
 memory_agent = None
 powermemory = None
+# Becomes True only after AsyncMemory.initialize() succeeds. The powermem
+# tools are gated on this so a failed/slow init degrades gracefully (the
+# tools are simply hidden) instead of producing undefined behaviour.
+powermemory_ready = False
 
 if app_config.agent_powermem_config is not None:
     # for group memory, the key is f"group_{chat_id}"
     powermemory = AsyncMemory(app_config.agent_powermem_config)
 
     async def _init_powermem():
+        global powermemory_ready
         assert powermemory is not None
-        await powermemory.initialize()
+        try:
+            await powermemory.initialize()
+            powermemory_ready = True
+            logger.info("powermem initialized successfully")
+        except Exception as e:
+            logger.exception(
+                f"Failed to initialize powermem, group memory tools will be "
+                f"disabled: {e.__class__.__name__} - {e}"
+            )
 
-    asyncio.create_task(_init_powermem())
+    common.spawn(_init_powermem(), name="powermem-init")
 
 
 _history_compressor: HistoryCompressor | None = None
@@ -241,7 +255,7 @@ if app_config.agent and app_config.agent_model:
             ),
         ],
         deps_type=datatype.ContextDeps,
-        history_processors=[history_processor],
+        capabilities=[ProcessHistory(history_processor)],
         retries=5,
     )
 

--- a/kmua/plugins/agent/output.py
+++ b/kmua/plugins/agent/output.py
@@ -15,6 +15,11 @@ from kmua.plugins.agent.styling import convert_md
 
 _MD_SEPARATOR_RE = re.compile(r"^(?:[-*_][ \t]*){3,}$")
 
+# Upper bound on the cumulative inter-chunk delay in reply_output. Without this
+# cap, a long reply split into many chunks could keep a dispatcher worker busy
+# (holding its handler lock) for tens of seconds purely on sleeps.
+_MAX_TOTAL_REPLY_DELAY = 12.0
+
 
 def _is_markdown_separator_only_chunk(chunk: str) -> bool:
     lines = [line.strip() for line in chunk.splitlines() if line.strip()]
@@ -74,6 +79,7 @@ async def reply_output(
                 logger.warning(f"Send failed: {e.__class__.__name__} - {e}")
                 last_reply_msg = await message.reply_text(total_plain)
         else:
+            total_delay = 0.0
             for chunk in chunks:
                 # 如果只有分隔符, 则跳过
                 if _is_markdown_separator_only_chunk(chunk):
@@ -90,7 +96,11 @@ async def reply_output(
                         logger.error(f"Send failed: {e.__class__.__name__} - {e}")
                         raise
                 last_reply_msg = reply_msg
-                await asyncio.sleep(random.uniform(0.721, 3.9) + len(chunk) / 600)
+                if total_delay < _MAX_TOTAL_REPLY_DELAY:
+                    delay = random.uniform(0.721, 3.9) + len(chunk) / 600
+                    delay = min(delay, _MAX_TOTAL_REPLY_DELAY - total_delay)
+                    total_delay += delay
+                    await asyncio.sleep(delay)
         if (
             last_reply_msg
             and last_reply_msg.text

--- a/kmua/plugins/agent/runner.py
+++ b/kmua/plugins/agent/runner.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 
 import pydantic_ai
@@ -59,6 +60,63 @@ async def set_chat_prompt_override(chat_id: int, prompt: str | None) -> None:
 
 
 async def run_agent(
+    agi: Agent[Any, Any],
+    client: PyrogramClient,
+    message: pyrogram.types.Message,
+    user_id: int,
+    chat_id: int,
+    user_prompt: list[UserContent],
+    history: list[ModelMessage],
+    deps: Any,
+    multimodal_model: Any,
+    model: Any,
+    lang: str,
+    additional_instructions: str | None = None,
+) -> None:
+    """Run the agent with an overall wall-clock timeout guard.
+
+    Wraps :func:`_run_agent_impl` with ``asyncio.wait_for`` so that a stuck
+    model response or tool call can never block a dispatcher worker (and thus
+    the whole event loop) indefinitely. The timeout is controlled by
+    ``app_config.agent_run_timeout`` (0 disables it).
+    """
+    timeout = app_config.agent_run_timeout
+    coro = _run_agent_impl(
+        agi=agi,
+        client=client,
+        message=message,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_prompt=user_prompt,
+        history=history,
+        deps=deps,
+        multimodal_model=multimodal_model,
+        model=model,
+        lang=lang,
+        additional_instructions=additional_instructions,
+    )
+    if not timeout or timeout <= 0:
+        await coro
+        return
+    try:
+        await asyncio.wait_for(coro, timeout=timeout)
+    except TimeoutError:
+        logger.warning(
+            f"Agent run timed out after {timeout}s for user {user_id} in chat {chat_id}"
+        )
+        try:
+            err_text = i18n.t("bot.msg.agent.errors.interrupted", locale=lang).format(
+                error="Timeout"
+            )
+            if deps.is_guest_mode:
+                await reply_output(client, message, err_text, deps=deps)
+            else:
+                await message.reply_text(err_text)
+        except Exception as e:
+            logger.error(f"Failed to send timeout notice: {e.__class__.__name__} - {e}")
+
+
+async def _run_agent_impl(
     agi: Agent[Any, Any],
     client: PyrogramClient,
     message: pyrogram.types.Message,

--- a/kmua/plugins/agent/sticker_memory.py
+++ b/kmua/plugins/agent/sticker_memory.py
@@ -155,4 +155,7 @@ async def on_sticker(client: PyrogramClient, message: pyrogram.types.Message) ->
         return
     if not (await database.get_chat_config(chat.id)).ai_reply:
         return
-    asyncio.create_task(_process_sticker(client, sticker, chat.id))
+    common.spawn(
+        _process_sticker(client, sticker, chat.id),
+        name=f"sticker-memory-{chat.id}",
+    )

--- a/kmua/plugins/agent/tools/prepare.py
+++ b/kmua/plugins/agent/tools/prepare.py
@@ -87,9 +87,13 @@ async def prepare_message_search_tool(
 async def prepare_powermem_tool(
     ctx: RunContext[datatype.ContextDeps], tool_def: ToolDefinition
 ) -> ToolDefinition | None:
+    # Import lazily to avoid a circular import (agent -> tools -> prepare).
+    from kmua.plugins.agent import agent as _agent
+
     if (
         app_config.agent_powermem_config is not None
         and ctx.deps.powermemory is not None
+        and _agent.powermemory_ready  # init finished successfully
         and ctx.deps.chat_id < -100  # current powermem tool is only for group chat
     ):
         return tool_def

--- a/kmua/plugins/agent/tools/web.py
+++ b/kmua/plugins/agent/tools/web.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 from dataclasses import dataclass
 from typing import Any, cast
@@ -49,8 +50,13 @@ def _truncate(text: str) -> str:
 
 
 async def _fetch_http(url: str) -> WebFetchResult:
+    timeout = app_config.agent_webfetch_timeout
     async with AsyncWebCrawler(crawler_strategy=_http_strategy) as crawler:
-        raw = await crawler.arun(url, config=_run_config)
+        coro = crawler.arun(url, config=_run_config)
+        if timeout and timeout > 0:
+            raw = await asyncio.wait_for(coro, timeout=timeout)
+        else:
+            raw = await coro
     result = cast(CrawlResult, raw)
     if not result.success:
         return WebFetchResult(
@@ -378,6 +384,13 @@ async def webfetch(ctx: RunContext[datatype.ContextDeps], url: str) -> WebFetchR
         if app_config.agent_crawl_api_url:
             return await _fetch_crawl_api(url)
         return await _fetch_http(url)
+    except TimeoutError:
+        logger.warning(f"webfetch timed out for {url}")
+        return WebFetchResult(
+            success=False,
+            url=url,
+            error="Fetch timed out",
+        )
     except Exception as e:
         logger.error(f"webfetch error for {url}: {e.__class__.__name__}: {e}")
         return WebFetchResult(

--- a/kmua/plugins/help.py
+++ b/kmua/plugins/help.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pyrogram
 
-from kmua import database, i18n
+from kmua import common, database, i18n
 
 
 @pyrogram.Client.on_message(pyrogram.filters.command("help"), group=0)
@@ -23,7 +23,7 @@ async def help_command(client: pyrogram.Client, message: pyrogram.types.Message)
 
     reply = await message.reply_text(text, parse_mode=pyrogram.enums.ParseMode.HTML)
     if in_group:
-        asyncio.create_task(_auto_delete(reply, 120))
+        common.spawn(_auto_delete(reply, 120), name="help-auto-delete")
 
 
 async def _auto_delete(message: pyrogram.types.Message, delay: int = 120) -> None:

--- a/kmua/plugins/quote/quote.py
+++ b/kmua/plugins/quote/quote.py
@@ -8,6 +8,7 @@ from pyrogram.client import Client as PyrogramClient
 
 from kmua import common, database, i18n
 from kmua.common.utils import is_explicit_reply
+from kmua.config import app_config
 
 from . import utils
 

--- a/kmua/plugins/start.py
+++ b/kmua/plugins/start.py
@@ -241,7 +241,7 @@ async def start_group(client: Client, message: Message):
             ]
         ),
     )
-    asyncio.create_task(_auto_delete(reply, 120))
+    common.spawn(_auto_delete(reply, 120), name="group-start-auto-delete")
 
 
 @Client.on_callback_query(filters.regex(r"^back_home"))


### PR DESCRIPTION
主要为防止单线程事件循环被长时间阻塞:
- 主 Agent run 增加整体超时保护 (asyncio.wait_for)
- webfetch 的 crawl4ai 抓取增加超时
- powermem 初始化改用安全的后台任务, 失败时优雅降级
- 新增 common.spawn 统一管理后台任务 (保持强引用 + 记录异常), 替换各处裸 asyncio.create_task
- 分段回复的累计 sleep 设置总时长上限
- 新增事件循环卡顿监控 (loop_monitor), 卡顿超阈值时 dump 任务栈

顺带修复:
- agent.py 迁移废弃的 history_processors 到 capabilities=[ProcessHistory(...)]
- quote.py 补充缺失的 app_config 导入
- client.py 修正 max_concurrent_transmissions 运算符优先级