### PR TITLE
feat(rss): added RSS/Atom subscription support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,3 @@ webapp/.env.local
 # stay out of the repo and out of the docs site.
 .dev-notes/
 # Runtime configuration with real credentials - never commit.
-settings.toml

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ webapp/.env.local
 # Working notes: design plans, local dev scratch. Not user documentation, so they
 # stay out of the repo and out of the docs site.
 .dev-notes/
+# Runtime configuration with real credentials - never commit.
+settings.toml

--- a/alembic/versions/c1d2e3f4a5b6_add_rss_subscriptions.py
+++ b/alembic/versions/c1d2e3f4a5b6_add_rss_subscriptions.py
@@ -1,0 +1,101 @@
+"""add_rss_subscriptions
+
+Revision ID: c1d2e3f4a5b6
+Revises: b7c8d9e0f1a2
+Create Date: 2026-07-31 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "c1d2e3f4a5b6"
+down_revision: str | None = "b7c8d9e0f1a2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    bind = op.get_bind()
+    insp = sa.inspect(bind)
+
+    if not insp.has_table("rss_feeds"):
+        op.create_table(
+            "rss_feeds",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("url", sa.String(length=1024), nullable=False),
+            sa.Column("title", sa.String(length=512), nullable=True),
+            sa.Column("etag", sa.String(length=256), nullable=True),
+            sa.Column("last_modified", sa.String(length=256), nullable=True),
+            sa.Column("seen_entry_ids", sa.JSON(), nullable=True),
+            sa.Column("last_fetched_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_error", sa.String(length=512), nullable=True),
+            sa.Column(
+                "failure_count",
+                sa.Integer(),
+                nullable=False,
+                server_default=sa.text("0"),
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("(CURRENT_TIMESTAMP)"),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("url", name="uq_rss_feeds_url"),
+        )
+        op.create_index(op.f("ix_rss_feeds_id"), "rss_feeds", ["id"], unique=False)
+
+    if not insp.has_table("rss_subscriptions"):
+        op.create_table(
+            "rss_subscriptions",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("feed_id", sa.Integer(), nullable=False),
+            sa.Column("chat_id", sa.BigInteger(), nullable=False),
+            sa.Column("created_by", sa.BigInteger(), nullable=True),
+            sa.Column(
+                "paused", sa.Boolean(), nullable=False, server_default=sa.text("false")
+            ),
+            sa.Column("interval_minutes", sa.Integer(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.text("(CURRENT_TIMESTAMP)"),
+                nullable=False,
+            ),
+            sa.ForeignKeyConstraint(["feed_id"], ["rss_feeds.id"], ondelete="CASCADE"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "chat_id", "feed_id", name="uq_rss_subscription_chat_feed"
+            ),
+        )
+        op.create_index(
+            op.f("ix_rss_subscriptions_id"), "rss_subscriptions", ["id"], unique=False
+        )
+        op.create_index(
+            op.f("ix_rss_subscriptions_feed_id"),
+            "rss_subscriptions",
+            ["feed_id"],
+            unique=False,
+        )
+        op.create_index(
+            op.f("ix_rss_subscriptions_chat_id"),
+            "rss_subscriptions",
+            ["chat_id"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_rss_subscriptions_chat_id"), table_name="rss_subscriptions")
+    op.drop_index(op.f("ix_rss_subscriptions_feed_id"), table_name="rss_subscriptions")
+    op.drop_index(op.f("ix_rss_subscriptions_id"), table_name="rss_subscriptions")
+    op.drop_table("rss_subscriptions")
+    op.drop_index(op.f("ix_rss_feeds_id"), table_name="rss_feeds")
+    op.drop_table("rss_feeds")

--- a/kmua/__main__.py
+++ b/kmua/__main__.py
@@ -149,6 +149,7 @@ async def init_bot(client: Client = client):
         BotCommand("pickbottle", i18n.t("bot.cmd.pickbottle", locale=app_config.lang)),
         BotCommand("id", i18n.t("bot.cmd.id", locale=app_config.lang)),
         BotCommand("f5avatar", i18n.t("bot.cmd.f5avatar", locale=app_config.lang)),
+        BotCommand("rss", i18n.t("bot.cmd.rss", locale=app_config.lang)),
     ]
     if app_config.agent:
         common_commands.append(
@@ -254,6 +255,16 @@ async def init_bot(client: Client = client):
             "change_bot_avatar",
             jobs.change_bot_avatar,
             hours=app_config.avatar_change_interval,
+        )
+
+    if app_config.rss_enabled:
+        # The job ticks every minute and each feed decides whether it is due,
+        # so per-subscription intervals (else the global `rss_interval`) are
+        # honored without registering one scheduler job per feed.
+        common.jobqueue.add_interval_job(
+            "rss_push",
+            jobs.rss_push,
+            minutes=1,
         )
 
     await _setup_menu_button(client)

--- a/kmua/bot/jobs.py
+++ b/kmua/bot/jobs.py
@@ -1,8 +1,11 @@
+import asyncio
 import io
 import random
+from datetime import UTC, datetime, timedelta
 
 import httpx
 import pyrogram
+import pyrogram.errors
 
 from kmua import common, database, enums, i18n
 from kmua.config import app_config
@@ -70,3 +73,193 @@ async def change_bot_avatar():
                 error=str(e)
             )
         )
+
+
+async def rss_push():
+    """Poll every active feed whose cadence is due, and deliver new entries.
+
+    Runs every minute (see the `__main__` registration) but only fetches feeds
+    whose effective interval has elapsed: the effective interval of a feed is the
+    minimum across its unpaused subscriptions, falling back to
+    `app_config.rss_interval` for subscriptions without their own. Feeds are
+    polled sequentially rather than concurrently: this runs on the bot's only
+    event loop, and a burst of parallel fetches competes with message handling
+    for it.
+    """
+    if not app_config.rss_enabled:
+        return
+
+    from kmua.services import rss as rss_service
+    from kmua.services.rss import redact_url
+
+    feeds = await database.get_active_feeds()
+    if not feeds:
+        return
+
+    now = datetime.now(UTC)
+    pushed = 0
+    fetched = 0
+    for feed, interval_minutes in feeds:
+        if feed.failure_count >= rss_service.MAX_FAILURES:
+            logger.warning(
+                f"rss: skipping feed {feed.id} ({feed.url}) after "
+                f"{feed.failure_count} consecutive failures"
+            )
+            continue
+
+        if feed.last_fetched_at is not None:
+            last = feed.last_fetched_at
+            if last.tzinfo is None:
+                last = last.replace(tzinfo=UTC)
+            if now - last < timedelta(minutes=interval_minutes):
+                continue
+        fetched += 1
+
+        try:
+            result = await rss_service.fetch_feed(
+                feed.url, etag=feed.etag, last_modified=feed.last_modified
+            )
+        except Exception as e:
+            error = f"{e.__class__.__name__}: {e}"
+            # The exception string embeds the full request URL; a signed feed
+            # URL must not reach the logs or the `last_error` column.
+            error = error.replace(feed.url, redact_url(feed.url))
+            logger.error(f"rss: fetch failed for {redact_url(feed.url)}: {error}")
+            await database.record_fetch_failure(feed.id, error)
+            continue
+
+        if result.not_modified:
+            # A 304 is still a fetch: bump the timestamp so the next tick does
+            # not immediately re-request.
+            await database.touch_fetch(feed.id)
+            continue
+
+        if feed.last_fetched_at is None:
+            # First fetch: seed the seen window without pushing anything, so a fresh
+            # subscription is not flooded with the feed's entire history.
+            await database.record_fetch_success(
+                feed.id,
+                title=result.feed_title,
+                etag=result.etag,
+                last_modified=result.last_modified,
+                seen_entry_ids=[e.entry_id for e in result.entries],
+            )
+            continue
+
+        seen = set(feed.seen_entry_ids or [])
+        new_entries = [e for e in result.entries if e.entry_id not in seen][
+            : rss_service.MAX_ENTRIES_PER_PUSH
+        ]
+
+        # The seen window slides regardless of whether anything is new, so an entry
+        # that fell out of the window cannot be re-pushed on the next poll.
+        await database.record_fetch_success(
+            feed.id,
+            title=result.feed_title,
+            etag=result.etag,
+            last_modified=result.last_modified,
+            seen_entry_ids=[e.entry_id for e in result.entries] + list(seen),
+        )
+
+        if not new_entries:
+            continue
+
+        chat_ids = await database.get_feed_target_chats(feed.id)
+        lang_by_chat: dict[int, str] = {}
+        for chat_id in chat_ids:
+            if chat_id not in lang_by_chat:
+                lang_by_chat[chat_id] = await _chat_lang(chat_id)
+            for entry in new_entries:
+                text = rss_service.render_entry(
+                    result.feed_title or feed.url, entry, lang_by_chat[chat_id]
+                )
+                if await _deliver_entry(chat_id, text, entry.media_urls):
+                    pushed += 1
+                await asyncio.sleep(0.5)
+
+    logger.info(
+        f"rss: {len(feeds)} active feed(s), fetched {fetched}, "
+        f"pushed {pushed} message(s)"
+    )
+
+
+async def _chat_lang(chat_id: int) -> str:
+    """Resolve the delivery language for one chat.
+
+    Groups and channels store it in their chat config. A private chat is a user,
+    not a chat, so it has no chat_data row - fall back to the user config, and to
+    the bot-wide language when even that is unavailable. A missing row must never
+    abort the poll or drop the subscription: `_deliver_entry` decides whether the
+    chat is reachable, and permanent delivery failures are the only cleanup path.
+    """
+    try:
+        return (await database.get_chat_config(chat_id)).lang
+    except ValueError:
+        pass
+    if chat_id < 0:
+        return app_config.lang
+    try:
+        return (await database.get_user_config(chat_id)).lang
+    except Exception:
+        return app_config.lang
+
+
+async def _deliver_entry(chat_id: int, text: str, media_urls: list[str]) -> bool:
+    """Send one rendered entry. False when the chat is gone and was cleaned up.
+
+    With media, the text becomes the photo's caption (Telegram's 1024-char limit
+    applies); without it the entry is a plain text message. Either way the text
+    is shrunk to fit without breaking its HTML.
+    """
+    from kmua.bot.client import client
+    from kmua.services import rss as rss_service
+
+    async def send() -> None:
+        if media_urls:
+            await client.send_photo(
+                chat_id,
+                photo=media_urls[0],
+                caption=rss_service.truncate_for_delivery(text, 1024),
+                parse_mode=pyrogram.enums.ParseMode.HTML,
+            )
+        else:
+            await client.send_message(
+                chat_id,
+                rss_service.truncate_for_delivery(text, 4096),
+                parse_mode=pyrogram.enums.ParseMode.HTML,
+                disable_web_page_preview=False,
+            )
+
+    try:
+        await send()
+        return True
+    except pyrogram.errors.FloodWait as e:
+        logger.warning(f"rss: flood wait {e.value}s for chat {chat_id}")
+        # pyrogram annotates `FloodWait.value` loosely (int | str | RpcError); it
+        # is an int at runtime, and getattr sidesteps the annotation.
+        await asyncio.sleep(int(getattr(e, "value", 1)) + 1)
+        try:
+            await send()
+            return True
+        except Exception as retry_error:
+            logger.error(
+                f"rss: retry after flood failed for chat {chat_id}: {retry_error}"
+            )
+            return False
+    except (
+        pyrogram.errors.ChatWriteForbidden,
+        pyrogram.errors.ChannelPrivate,
+        pyrogram.errors.UserIsBlocked,
+        pyrogram.errors.PeerIdInvalid,
+    ):
+        # The chat is unreachable for good; keeping its subscriptions would make
+        # every future poll fail the same way. This is the only path that removes
+        # subscriptions automatically.
+        await database.delete_chat_subscriptions(chat_id)
+        logger.info(f"rss: chat {chat_id} unreachable, subscriptions cleaned up")
+        return False
+    except Exception as e:
+        logger.error(
+            f"rss: deliver to chat {chat_id} failed: {e.__class__.__name__}: {e}"
+        )
+        return False

--- a/kmua/config/__init__.py
+++ b/kmua/config/__init__.py
@@ -287,6 +287,17 @@ class _AppConfig(pydantic.BaseModel):
     # 每次奖励的数量
     coin_daily_add_count: int = 144 * 16
 
+    # RSS subscription push.
+    #
+    # Whitelist mode is ON by default: polling arbitrary URLs on a chat's behalf is an
+    # outbound-request grant, so a chat needs an explicit `rss_allowed` policy row
+    # (set by an owner in the panel) before it can subscribe. Turning this off lets
+    # every chat subscribe.
+    rss_enabled: bool = True
+    rss_whitelist_mode: bool = True
+    # Minutes between polls of every active feed.
+    rss_interval: int = pydantic.Field(default=30, ge=1, le=1440)
+
 
 class _InternalConfig(pydantic.BaseModel):
     db_is_sqlite: bool = False

--- a/kmua/database/__init__.py
+++ b/kmua/database/__init__.py
@@ -7,3 +7,4 @@ from .bottle import *  # noqa
 from .affection import *  # noqa
 from .gift import *  # noqa
 from .stats import *  # noqa
+from .rss import *  # noqa

--- a/kmua/database/models.py
+++ b/kmua/database/models.py
@@ -414,12 +414,17 @@ class ChatPolicy:
 
     # Whether the AI agent may act here, when agent_whitelist_mode is on.
     agent_allowed: bool = False
+    # Whether RSS subscriptions may be created here, when rss_whitelist_mode is on.
+    rss_allowed: bool = False
 
     @classmethod
     def from_dict(cls, data: dict | None) -> "ChatPolicy":
         if data is None:
             return cls()
-        return cls(agent_allowed=data.get("agent_allowed", False))
+        return cls(
+            agent_allowed=data.get("agent_allowed", False),
+            rss_allowed=data.get("rss_allowed", False),
+        )
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -509,3 +514,92 @@ class Gift(Base):
         return (
             f"<Gift(id={self.id}, owner_id={self.owner_id}, gift_id='{self.gift_id}')>"
         )
+
+
+class RssFeed(Base):
+    """One remote feed, fetched once however many chats subscribe to it.
+
+    Deduplicated by URL: polling the same feed once per subscriber would multiply
+    outbound requests by the subscriber count for identical bytes.
+
+    `seen_entry_ids` is the newest-N entry ids from the last successful fetch, and it
+    is how "new" is decided. Timestamps are not usable for this: `published_parsed`
+    is missing or wrong on a large share of real feeds, and a feed that republishes
+    with a bumped date would re-push every entry. An id set has no such failure mode.
+    """
+
+    __tablename__ = "rss_feeds"
+
+    id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, autoincrement=True, index=True
+    )
+    url: Mapped[str] = mapped_column(String(1024), nullable=False, unique=True)
+    # Feed's self-reported title, shown in listings. None until the first fetch.
+    title: Mapped[str | None] = mapped_column(String(512), nullable=True)
+
+    # Conditional-GET state, replayed as request headers on the next poll.
+    etag: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    last_modified: Mapped[str | None] = mapped_column(String(256), nullable=True)
+
+    # Entry ids already delivered; see the class docstring.
+    seen_entry_ids: Mapped[list] = mapped_column(JSON, default=list)
+
+    last_fetched_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+    # Last failure text, cleared on success. Surfaced in /rss list and the panel so a
+    # dead feed is visible instead of silently never pushing.
+    last_error: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    # Consecutive failures. At >= MAX_FAILURES the feed is skipped by the poll job.
+    failure_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=sa.text("0")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    def __repr__(self) -> str:
+        return f"<RssFeed(id={self.id}, url='{self.url}')>"
+
+
+class RssSubscription(Base):
+    """One chat's subscription to one feed.
+
+    No FK to `chat_data`: like `chat_policy`, a subscription may be created for a chat
+    before the bot has any row for it, and purging a chat should not silently drop a
+    deliberate subscription. The push job resolves the chat id against Telegram anyway.
+    """
+
+    __tablename__ = "rss_subscriptions"
+
+    id: Mapped[int] = mapped_column(
+        Integer, primary_key=True, autoincrement=True, index=True
+    )
+    feed_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("rss_feeds.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False, index=True)
+    # Who created it, for the audit trail. Not an FK, as above.
+    created_by: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    paused: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=sa.text("false")
+    )
+    # Per-subscription poll interval in minutes; None means "follow the global
+    # rss_interval". The feed's effective interval is the minimum across its
+    # unpaused subscriptions.
+    interval_minutes: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )
+
+    feed: Mapped[RssFeed] = relationship(lazy="joined")
+
+    __table_args__ = (
+        sa.UniqueConstraint("chat_id", "feed_id", name="uq_rss_subscription_chat_feed"),
+    )
+
+    def __repr__(self) -> str:
+        return f"<RssSubscription(chat_id={self.chat_id}, feed_id={self.feed_id})>"

--- a/kmua/database/rss.py
+++ b/kmua/database/rss.py
@@ -1,0 +1,454 @@
+"""RSS/Atom subscription storage.
+
+Two concerns, deliberately separated from each other:
+
+1. Deduplication. A feed is a row in `rss_feeds`, shared by however many chats
+   subscribe to it, so the poll job fetches each URL once and fans out. A chat's
+   subscription (`rss_subscriptions`) is a thin join row on top of that.
+2. Whitelisting. `rss_allowed` is a `ChatPolicy` flag (JSON column, no migration):
+   when `rss_whitelist_mode` is on, only chats the owner has explicitly allowed may
+   subscribe at all. Unlike the agent flag, RSS checks all happen in async contexts
+   (command handlers, HTTP endpoints), so there is no in-memory mirror here — the DB
+   is read directly, and `is_rss_allowed` is deliberately NOT a `chat_policy.py`
+   mirror getter.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import sqlalchemy
+import sqlalchemy.orm
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from kmua.config import app_config
+from kmua.database import pagination
+from kmua.database.db import with_session, with_tx
+from kmua.database.models import ChatPolicyData, RssFeed, RssSubscription
+
+MAX_FEEDS_PER_CHAT = 20
+"""Per-chat cap. Guards against one chat turning the poll job into a crawler."""
+
+MAX_SEEN_IDS = 200
+"""How many entry ids to remember per feed. Comfortably above any feed's page size,
+so an entry cannot fall out of the window and be re-pushed as new."""
+
+MIN_SUBSCRIPTION_INTERVAL = 1
+MAX_SUBSCRIPTION_INTERVAL = 1440
+"""Per-subscription poll interval bounds, in minutes. None means global."""
+
+
+@with_session
+async def is_rss_allowed(chat_id: int, session: AsyncSession | None = None) -> bool:
+    """Whether this chat may use RSS at all.
+
+    Reads the `rss_allowed` policy flag. Returns True unconditionally when
+    `app_config.rss_whitelist_mode` is off, matching `is_chat_allowed`'s shape.
+    """
+    assert session is not None
+
+    if not app_config.rss_whitelist_mode:
+        return True
+
+    row = await session.get(ChatPolicyData, chat_id)
+    return row.chat_policy.rss_allowed if row else False
+
+
+@with_tx
+async def get_or_create_feed(url: str, session: AsyncSession | None = None) -> RssFeed:
+    """The feed row for `url`, inserted if absent. Dedupes by exact URL."""
+    assert session is not None
+
+    row = await get_feed_by_url(url, session=session)
+    if row is not None:
+        return row
+
+    feed = RssFeed(url=url)
+    session.add(feed)
+    await session.flush()
+    return feed
+
+
+@with_session
+async def get_feed_by_url(
+    url: str, session: AsyncSession | None = None
+) -> RssFeed | None:
+    assert session is not None
+
+    stmt = sqlalchemy.select(RssFeed).where(RssFeed.url == url)
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+@with_session
+async def get_feed_by_id(
+    feed_id: int, session: AsyncSession | None = None
+) -> RssFeed | None:
+    assert session is not None
+
+    return await session.get(RssFeed, feed_id)
+
+
+@with_tx
+async def add_subscription(
+    chat_id: int,
+    url: str,
+    *,
+    created_by: int | None = None,
+    session: AsyncSession | None = None,
+) -> tuple[RssSubscription | None, str | None]:
+    """Subscribe `chat_id` to `url`.
+
+    Returns `(subscription, None)` on success, or `(None, reason)` where reason is
+    exactly one of the literals "already_subscribed" or "limit_reached". Returning a
+    reason rather than raising keeps the command handler and the HTTP endpoint able to
+    map the same outcome onto their own vocabularies.
+    """
+    assert session is not None
+
+    if await count_chat_subscriptions(chat_id, session=session) >= MAX_FEEDS_PER_CHAT:
+        return None, "limit_reached"
+
+    try:
+        feed = await get_or_create_feed(url, session=session)
+        existing = (
+            await session.execute(
+                sqlalchemy.select(RssSubscription).where(
+                    RssSubscription.chat_id == chat_id,
+                    RssSubscription.feed_id == feed.id,
+                )
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            return None, "already_subscribed"
+
+        sub = RssSubscription(chat_id=chat_id, feed_id=feed.id, created_by=created_by)
+        session.add(sub)
+        await session.flush()
+    except IntegrityError:
+        # Two interleaved adds (same URL from two chats, or a double tap) can
+        # both pass the select and one flush hits the unique constraints. The
+        # row the other caller created is exactly what this caller wanted.
+        await session.rollback()
+        return None, "already_subscribed"
+
+    # Re-select with the feed joined: `lazy="joined"` applies to queries, not to a
+    # freshly flushed row, and callers serialize `sub.feed` after this session is
+    # closed.
+    loaded = (
+        await session.execute(
+            sqlalchemy.select(RssSubscription)
+            .options(sqlalchemy.orm.joinedload(RssSubscription.feed))
+            .where(RssSubscription.id == sub.id)
+        )
+    ).scalar_one()
+    return loaded, None
+
+
+@with_tx
+async def remove_subscription(
+    chat_id: int, feed_id: int, session: AsyncSession | None = None
+) -> bool:
+    """Unsubscribe. False when the chat had no such subscription.
+
+    Also deletes the feed row when this was its last subscriber, so an unsubscribed
+    feed stops being polled instead of lingering forever.
+    """
+    assert session is not None
+
+    sub = (
+        await session.execute(
+            sqlalchemy.select(RssSubscription).where(
+                RssSubscription.chat_id == chat_id,
+                RssSubscription.feed_id == feed_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if sub is None:
+        return False
+
+    await session.delete(sub)
+    await session.flush()
+
+    remaining = (
+        await session.execute(
+            sqlalchemy.select(sqlalchemy.func.count())
+            .select_from(RssSubscription)
+            .where(RssSubscription.feed_id == feed_id)
+        )
+    ).scalar() or 0
+    if remaining == 0:
+        feed = await session.get(RssFeed, feed_id)
+        if feed is not None:
+            await session.delete(feed)
+    await session.flush()
+    return True
+
+
+@with_tx
+async def set_subscription_paused(
+    chat_id: int, feed_id: int, paused: bool, session: AsyncSession | None = None
+) -> bool:
+    """Pause/resume. False when the chat had no such subscription."""
+    assert session is not None
+
+    sub = (
+        await session.execute(
+            sqlalchemy.select(RssSubscription).where(
+                RssSubscription.chat_id == chat_id,
+                RssSubscription.feed_id == feed_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if sub is None:
+        return False
+
+    sub.paused = paused
+    await session.flush()
+    return True
+
+
+@with_session
+async def get_chat_subscriptions(
+    chat_id: int, session: AsyncSession | None = None
+) -> list[RssSubscription]:
+    """Every subscription for one chat, newest first. Feed eagerly loaded."""
+    assert session is not None
+
+    stmt = (
+        sqlalchemy.select(RssSubscription)
+        .options(sqlalchemy.orm.joinedload(RssSubscription.feed))
+        .where(RssSubscription.chat_id == chat_id)
+        .order_by(RssSubscription.created_at.desc(), RssSubscription.id.desc())
+    )
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@with_session
+async def get_chat_subscriptions_paged(
+    chat_id: int,
+    *,
+    page: int = 1,
+    size: int = pagination.DEFAULT_PAGE_SIZE,
+    session: AsyncSession | None = None,
+) -> pagination.Page[RssSubscription]:
+    """Paged variant for the panel. Uses `pagination.normalize_page`/`offset_for`."""
+    assert session is not None
+
+    page, size = pagination.normalize_page(page, size)
+
+    total = (
+        await session.execute(
+            sqlalchemy.select(sqlalchemy.func.count())
+            .select_from(RssSubscription)
+            .where(RssSubscription.chat_id == chat_id)
+        )
+    ).scalar() or 0
+
+    stmt = (
+        sqlalchemy.select(RssSubscription)
+        .options(sqlalchemy.orm.joinedload(RssSubscription.feed))
+        .where(RssSubscription.chat_id == chat_id)
+        .order_by(RssSubscription.created_at.desc(), RssSubscription.id.desc())
+        .offset(pagination.offset_for(page, size))
+        .limit(size)
+    )
+    items = (await session.execute(stmt)).scalars().all()
+    return pagination.Page(items=items, total=total, page=page, size=size)
+
+
+@with_session
+async def count_chat_subscriptions(
+    chat_id: int, session: AsyncSession | None = None
+) -> int:
+    assert session is not None
+
+    stmt = (
+        sqlalchemy.select(sqlalchemy.func.count())
+        .select_from(RssSubscription)
+        .where(RssSubscription.chat_id == chat_id)
+    )
+    return (await session.execute(stmt)).scalar() or 0
+
+
+@with_session
+async def get_active_feeds(
+    session: AsyncSession | None = None,
+) -> list[tuple[RssFeed, int]]:
+    """Feeds to poll, each with its effective interval in minutes.
+
+    A feed with at least one unpaused subscription is active; a feed whose every
+    subscription is paused is skipped entirely: fetching bytes nobody will
+    receive is pure waste.
+
+    The effective interval is the minimum across the feed's unpaused
+    subscriptions (subscription-level minutes, else the global `rss_interval`)
+    - the subscriber who wants the fastest cadence sets the pace.
+    """
+    assert session is not None
+
+    global_minutes = app_config.rss_interval
+    effective = sqlalchemy.func.min(
+        sqlalchemy.func.coalesce(RssSubscription.interval_minutes, global_minutes)
+    )
+    stmt = (
+        sqlalchemy.select(RssFeed, effective)
+        .join(RssSubscription, RssSubscription.feed_id == RssFeed.id)
+        .where(RssSubscription.paused.is_(False))
+        .group_by(RssFeed.id)
+        .distinct()
+    )
+    rows = (await session.execute(stmt)).all()
+    return [(feed, int(minutes)) for feed, minutes in rows]
+
+
+@with_session
+async def get_feed_target_chats(
+    feed_id: int, session: AsyncSession | None = None
+) -> list[int]:
+    """Chat ids to deliver this feed to: unpaused subscriptions only."""
+    assert session is not None
+
+    stmt = (
+        sqlalchemy.select(RssSubscription.chat_id)
+        .where(
+            RssSubscription.feed_id == feed_id,
+            RssSubscription.paused.is_(False),
+        )
+        .order_by(RssSubscription.chat_id)
+    )
+    return list((await session.execute(stmt)).scalars().all())
+
+
+@with_tx
+async def record_fetch_success(
+    feed_id: int,
+    *,
+    title: str | None,
+    etag: str | None,
+    last_modified: str | None,
+    seen_entry_ids: list[str],
+    session: AsyncSession | None = None,
+) -> None:
+    """Commit post-fetch state: clears `last_error`, zeroes `failure_count`, sets
+    `last_fetched_at` to `datetime.now(UTC)`, and replaces `seen_entry_ids` with the
+    last `MAX_SEEN_IDS` ids. `title` only overwrites when non-empty."""
+    assert session is not None
+
+    feed = await session.get(RssFeed, feed_id)
+    if feed is None:
+        return
+
+    if title:
+        feed.title = title
+    feed.etag = etag
+    feed.last_modified = last_modified
+    feed.seen_entry_ids = seen_entry_ids[-MAX_SEEN_IDS:]
+    feed.last_error = None
+    feed.failure_count = 0
+    feed.last_fetched_at = datetime.now(UTC)
+    await session.flush()
+
+
+@with_tx
+async def record_fetch_failure(
+    feed_id: int, error: str, session: AsyncSession | None = None
+) -> None:
+    """Increment `failure_count`, store `error` truncated to 512 chars, and set
+    `last_fetched_at`."""
+    assert session is not None
+
+    feed = await session.get(RssFeed, feed_id)
+    if feed is None:
+        return
+
+    feed.failure_count += 1
+    feed.last_error = error[:512]
+    feed.last_fetched_at = datetime.now(UTC)
+    await session.flush()
+
+
+@with_tx
+async def set_subscription_interval(
+    chat_id: int,
+    feed_id: int,
+    minutes: int | None,
+    session: AsyncSession | None = None,
+) -> bool:
+    """Set one subscription's poll interval, in minutes; None = global default.
+
+    False when the chat had no such subscription.
+    """
+    assert session is not None
+
+    sub = (
+        await session.execute(
+            sqlalchemy.select(RssSubscription).where(
+                RssSubscription.chat_id == chat_id,
+                RssSubscription.feed_id == feed_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if sub is None:
+        return False
+
+    sub.interval_minutes = minutes
+    await session.flush()
+    return True
+
+
+@with_tx
+async def touch_fetch(feed_id: int, session: AsyncSession | None = None) -> None:
+    """Record that a poll happened without changing feed state (a 304).
+
+    Keeps the per-feed cadence honest: a not-modified response is still a fetch,
+    and without the timestamp bump the next tick would immediately re-request.
+    """
+    assert session is not None
+
+    feed = await session.get(RssFeed, feed_id)
+    if feed is None:
+        return
+    feed.last_fetched_at = datetime.now(UTC)
+    await session.flush()
+
+
+@with_tx
+async def delete_chat_subscriptions(
+    chat_id: int, session: AsyncSession | None = None
+) -> int:
+    """Drop every subscription for a chat, returning the count. Called when the bot
+    is kicked or the push job hits an unrecoverable delivery error."""
+    assert session is not None
+
+    stmt = sqlalchemy.delete(RssSubscription).where(RssSubscription.chat_id == chat_id)
+    result = await session.execute(stmt)
+    await session.flush()
+    # `execute` on a DELETE is a CursorResult at runtime; pyright cannot see that
+    # through the generic `Result` return annotation.
+    return int(result.rowcount or 0)  # type: ignore[attr-defined]
+
+
+__all__ = [
+    "MAX_FEEDS_PER_CHAT",
+    "MAX_SEEN_IDS",
+    "MIN_SUBSCRIPTION_INTERVAL",
+    "MAX_SUBSCRIPTION_INTERVAL",
+    "add_subscription",
+    "count_chat_subscriptions",
+    "delete_chat_subscriptions",
+    "get_active_feeds",
+    "get_chat_subscriptions",
+    "get_chat_subscriptions_paged",
+    "get_feed_by_id",
+    "get_feed_by_url",
+    "get_feed_target_chats",
+    "get_or_create_feed",
+    "is_rss_allowed",
+    "record_fetch_failure",
+    "record_fetch_success",
+    "remove_subscription",
+    "set_subscription_interval",
+    "set_subscription_paused",
+    "touch_fetch",
+]

--- a/kmua/i18n/locales/en/bot.yml
+++ b/kmua/i18n/locales/en/bot.yml
@@ -71,6 +71,7 @@ bot:
       /syncmembers - Sync group members
       /f5avatar - Refresh your avatar
       /forget - Make the bot forget your conversation history
+      /rss - Manage RSS subscriptions
       </blockquote>
       Use "/" or "\" on another user to cast a spell on them.
     help_inline: |
@@ -182,6 +183,37 @@ bot:
       rendered: "Rendered! Time: {time}ms"
       timeout: Rendering timeout, please try again later.
       error: "Rendering failed: {error}"
+    rss:
+      usage: |
+        <code>/rss sub &lt;url&gt;</code> to subscribe to an RSS/Atom feed
+        <code>/rss list</code> to show current subscriptions
+        <code>/rss unsub &lt;index&gt;</code> to unsubscribe
+        <code>/rss pause &lt;index&gt;</code> to pause push
+        <code>/rss resume &lt;index&gt;</code> to resume push
+        <code>/rss interval &lt;index&gt; &lt;minutes&gt;</code> to set the poll interval; omit minutes to reset to global
+        <code>/rss testpush &lt;index&gt;</code> to push this subscription immediately (for testing)
+      disabled: The RSS subscription feature is disabled.
+      not_allowed: "RSS subscriptions are not enabled for this chat (chat_id={chat_id}); ask the owner to allow it in the panel"
+      invalid_url: "Invalid URL: it must start with http:// or https://"
+      fetch_failed: "Could not fetch this feed: {error}"
+      added: "Subscribed: {title}"
+      already_subscribed: This feed is already in the subscription list.
+      limit_reached: "Subscription limit reached ({limit})"
+      empty: "No subscriptions yet. Try /rss sub <feed URL>"
+      removed: "Unsubscribed: {title}"
+      paused: "Paused: {title}"
+      resumed: "Resumed: {title}"
+      open_panel: Open panel
+      invalid_index: Invalid index.
+      interval_set: "Poll interval set to {minutes} minute(s)"
+      interval_reset: Poll interval reset to the global default.
+      interval_invalid: "Interval must be between {min} and {max} minutes"
+      too_many_requests: "Too many requests, slow down ({error})"
+      testpush_done: "Pushed {count} message(s)"
+      interval_mark: " · every {minutes} min"
+      paused_mark: " (paused)"
+      error_mark: " (push error)"
+      untitled: Untitled
     waifu:
       disabled: The waifu feature is not allowed here.
       not_found: You don't have a waifu right now because I can't find any other members in my records.
@@ -320,6 +352,7 @@ bot:
     greet: Set welcome message
     help: Help|More features
     infographic: Render infographic
+    rss: Manage RSS subscriptions
   button:
     back: Back
     repo: Source Code

--- a/kmua/i18n/locales/zh-CN/bot.cmd.yml
+++ b/kmua/i18n/locales/zh-CN/bot.cmd.yml
@@ -30,3 +30,4 @@ bot:
     randmyavatar: 立刻更换 bot 头像
     reload: 重载配置文件
     infographic: 渲染信息图
+    rss: 管理 RSS 订阅

--- a/kmua/i18n/locales/zh-CN/bot.yml
+++ b/kmua/i18n/locales/zh-CN/bot.yml
@@ -83,6 +83,7 @@ bot:
       /pickbottle - 捡一个漂流瓶
       /buygift - 购买礼物
       /gift - 送礼物给 Bot
+      /rss - 管理 RSS 订阅
       </blockquote>
       对其他人使用 "/" 或 "\" 即可对其施法
     help_inline: |
@@ -164,3 +165,34 @@ bot:
       rendered: "渲染完成! 耗时: {time}ms"
       timeout: 渲染超时, 请稍后再试
       error: "渲染失败: {error}"
+    rss:
+      usage: |
+        <code>/rss sub &lt;url&gt;</code> 订阅一个 RSS/Atom feed
+        <code>/rss list</code> 查看当前订阅
+        <code>/rss unsub &lt;序号&gt;</code> 取消订阅
+        <code>/rss pause &lt;序号&gt;</code> 暂停推送
+        <code>/rss resume &lt;序号&gt;</code> 恢复推送
+        <code>/rss interval &lt;序号&gt; &lt;分钟&gt;</code> 设置抓取间隔, 留空恢复全局
+        <code>/rss testpush &lt;序号&gt;</code> 立即推送一次该订阅 (测试用)
+      disabled: RSS 订阅功能未启用
+      not_allowed: "RSS 订阅未对此聊天开放"
+      invalid_url: URL 无效, 必须以 http:// 或 https:// 开头
+      fetch_failed: "无法获取该 feed: {error}"
+      added: "已添加订阅: {title}"
+      already_subscribed: 该 feed 已在订阅列表中
+      limit_reached: "订阅数量已达上限 ({limit})"
+      empty: "还没有订阅, 试试 /rss sub <feed URL>"
+      removed: "已取消订阅: {title}"
+      paused: "已暂停: {title}"
+      resumed: "已恢复: {title}"
+      open_panel: 打开面板
+      invalid_index: 序号无效
+      interval_set: "已设置抓取间隔为 {minutes} 分钟"
+      interval_reset: 已恢复为全局抓取间隔
+      interval_invalid: "间隔必须是 {min}-{max} 之间的分钟数"
+      too_many_requests: "操作太频繁, 请稍后再试 ({error})"
+      testpush_done: "已推送 {count} 条消息"
+      interval_mark: " · 每 {minutes} 分钟"
+      paused_mark: " (已暂停)"
+      error_mark: " (推送错误)"
+      untitled: 无标题

--- a/kmua/plugins/rss.py
+++ b/kmua/plugins/rss.py
@@ -1,0 +1,365 @@
+"""The `/rss` command: subscribe a chat to RSS/Atom feeds.
+
+Subcommands mirror the panel's subscription page: `sub <url>`, `list`, and
+`unsub`/`pause`/`resume` addressed by the 1-based index shown in `list` — a phone
+user should not have to retype a long URL to unpause a feed. `add`/`remove` are
+accepted as aliases for the newer `sub`/`unsub` spellings.
+
+The whitelist gate (`rss_allowed` policy flag) applies to every subcommand,
+including `list`: an un-whitelisted chat should not even see the feature.
+"""
+
+import html
+
+import pyrogram
+from pyrogram.client import Client as PyrogramClient
+
+from kmua import database, i18n
+from kmua.common.tgmethod import can_user_manage_bot_in_chat
+from kmua.config import app_config
+from kmua.logger import logger
+from kmua.plugins.panel import chat_panel_button, panel_available
+from kmua.services import rss as rss_service
+from kmua.services.rss import redact_url
+from kmua.webapp.errors import ApiError
+from kmua.webapp.ratelimit import SlidingWindowLimiter
+
+_T = pyrogram.types
+
+# Telegram's /rss add path has no write_limiter (that guards the HTTP API), so
+# the outbound validation fetch is throttled here per chat+user.
+_rss_add_limiter = SlidingWindowLimiter(limit=10, window=60.0)
+
+
+def _panel_markup(chat: _T.Chat, lang: str) -> _T.InlineKeyboardMarkup | None:
+    """A button into the panel for this chat, or None when the panel is not
+    configured. Groups get the `?startapp=` deep link (a Mini App button only
+    works in private chats); private chats get a real web-app button.
+    """
+    if not panel_available():
+        return None
+    if chat.type == pyrogram.enums.ChatType.PRIVATE:
+        button = _T.InlineKeyboardButton(
+            i18n.t("bot.msg.rss.open_panel", locale=lang),
+            web_app=_T.WebAppInfo(url=f"{app_config.webapp_url}/me/rss"),
+        )
+    else:
+        chat_id = chat.id
+        if chat_id is None:
+            return None
+        button = chat_panel_button(chat_id, lang)
+        if button is None:
+            return None
+    return _T.InlineKeyboardMarkup([[button]])
+
+
+@PyrogramClient.on_message(pyrogram.filters.command("rss"), group=0)
+async def rss_command(client: PyrogramClient, message: _T.Message):
+    if not app_config.rss_enabled:
+        await message.reply(i18n.t("bot.msg.rss.disabled", locale=app_config.lang))
+        return
+
+    chat = message.chat
+    user = message.from_user or message.sender_chat
+    if not user or not user.id or not chat or not chat.id:
+        return
+
+    if chat.type == pyrogram.enums.ChatType.PRIVATE:
+        lang = (await database.get_user_config(user.id)).lang
+    else:
+        chat_config = await database.get_chat_config(chat.id)
+        lang = chat_config.lang
+        # `can_user_manage_bot_in_chat` raises on private chats, so this branch
+        # must come after the private-chat check above.
+        if not await can_user_manage_bot_in_chat(user, chat):
+            await message.reply(i18n.t("bot.msg.no_permission_group", locale=lang))
+            return
+
+    if not await database.is_rss_allowed(chat.id):
+        await message.reply(
+            i18n.t("bot.msg.rss.not_allowed", locale=lang).format(chat_id=chat.id)
+        )
+        return
+
+    command = message.command or []
+    if len(command) < 2:
+        await message.reply(
+            i18n.t("bot.msg.rss.usage", locale=lang),
+            parse_mode=pyrogram.enums.ParseMode.HTML,
+            reply_markup=_panel_markup(chat, lang),
+        )
+        return
+
+    action = command[1].lower()
+    match action:
+        case "sub" | "add":
+            await _rss_add(message, chat, chat.id, user.id, lang, command)
+        case "list":
+            await _rss_list(message, chat, chat.id, lang)
+        case "unsub" | "remove" | "pause" | "resume":
+            await _rss_manage(message, chat.id, action, lang, command)
+        case "interval":
+            await _rss_interval(message, chat.id, lang, command)
+        case "testpush":
+            await _rss_testpush(client, message, chat.id, user.id, lang, command)
+        case _:
+            await message.reply(
+                i18n.t("bot.msg.rss.usage", locale=lang),
+                parse_mode=pyrogram.enums.ParseMode.HTML,
+                reply_markup=_panel_markup(chat, lang),
+            )
+
+
+async def _rss_add(
+    message: _T.Message,
+    chat: _T.Chat,
+    chat_id: int,
+    user_id: int,
+    lang: str,
+    command: list[str],
+) -> None:
+    url = " ".join(command[2:]).strip()
+    if not url.startswith(("http://", "https://")) or len(url) > 1024:
+        await message.reply(i18n.t("bot.msg.rss.invalid_url", locale=lang))
+        return
+
+    # The per-chat cap is enforced before any outbound fetch: a chat already at
+    # its cap must not be able to turn `/rss add` into an open fetcher.
+    if await database.count_chat_subscriptions(chat_id) >= database.MAX_FEEDS_PER_CHAT:
+        await message.reply(
+            i18n.t("bot.msg.rss.limit_reached", locale=lang).format(
+                limit=database.MAX_FEEDS_PER_CHAT
+            )
+        )
+        return
+
+    try:
+        _rss_add_limiter.check(f"{chat_id}:{user_id}")
+    except ApiError as e:
+        await message.reply(
+            i18n.t("bot.msg.rss.too_many_requests", locale=lang).format(error=e.message)
+        )
+        return
+
+    # Validate synchronously before subscribing: a URL that cannot be fetched
+    # today would otherwise be a silent never-pushing subscription.
+    try:
+        result = await rss_service.fetch_feed(url)
+    except Exception as e:
+        await message.reply(
+            i18n.t("bot.msg.rss.fetch_failed", locale=lang).format(
+                error=e.__class__.__name__
+            )
+        )
+        logger.error(f"rss: add validation fetch failed for {redact_url(url)}: {e}")
+        return
+
+    sub, reason = await database.add_subscription(chat_id, url, created_by=user_id)
+    if sub is None:
+        if reason == "already_subscribed":
+            await message.reply(i18n.t("bot.msg.rss.already_subscribed", locale=lang))
+        else:
+            await message.reply(
+                i18n.t("bot.msg.rss.limit_reached", locale=lang).format(
+                    limit=database.MAX_FEEDS_PER_CHAT
+                )
+            )
+        return
+
+    # Seed the seen window right away, matching the poll job's first-fetch rule:
+    # a fresh subscription must not be flooded with the feed's history on the
+    # next poll.
+    await database.record_fetch_success(
+        sub.feed_id,
+        title=result.feed_title,
+        etag=result.etag,
+        last_modified=result.last_modified,
+        seen_entry_ids=[e.entry_id for e in result.entries],
+    )
+
+    feed_title = result.feed_title or url
+    await message.reply(
+        i18n.t("bot.msg.rss.added", locale=lang).format(title=feed_title),
+        reply_markup=_panel_markup(chat, lang),
+    )
+
+
+async def _rss_list(
+    message: _T.Message, chat: _T.Chat, chat_id: int, lang: str
+) -> None:
+    subs = await database.get_chat_subscriptions(chat_id)
+    if not subs:
+        await message.reply(
+            i18n.t("bot.msg.rss.empty", locale=lang),
+            reply_markup=_panel_markup(chat, lang),
+        )
+        return
+
+    lines = []
+    for idx, sub in enumerate(subs, 1):
+        title = sub.feed.title or sub.feed.url
+        url = html.escape(sub.feed.url)
+        interval = sub.interval_minutes or app_config.rss_interval
+        line = f'{idx}. <a href="{url}">{html.escape(title)}</a>' + i18n.t(
+            "bot.msg.rss.interval_mark", locale=lang
+        ).format(minutes=interval)
+        if sub.paused:
+            line += i18n.t("bot.msg.rss.paused_mark", locale=lang)
+        if sub.feed.last_error:
+            line += i18n.t("bot.msg.rss.error_mark", locale=lang)
+        lines.append(line)
+    await message.reply(
+        "\n".join(lines),
+        parse_mode=pyrogram.enums.ParseMode.HTML,
+        reply_markup=_panel_markup(chat, lang),
+    )
+
+
+async def _rss_manage(
+    message: _T.Message, chat_id: int, action: str, lang: str, command: list[str]
+) -> None:
+    subs = await database.get_chat_subscriptions(chat_id)
+    try:
+        index = int(command[2]) - 1
+        sub = subs[index]
+    except (ValueError, IndexError):
+        await message.reply(i18n.t("bot.msg.rss.invalid_index", locale=lang))
+        return
+
+    feed_id = sub.feed_id
+    feed_title = sub.feed.title or sub.feed.url
+    match action:
+        case "unsub" | "remove":
+            await database.remove_subscription(chat_id, feed_id)
+            await message.reply(
+                i18n.t("bot.msg.rss.removed", locale=lang).format(title=feed_title)
+            )
+        case "pause":
+            await database.set_subscription_paused(chat_id, feed_id, True)
+            await message.reply(
+                i18n.t("bot.msg.rss.paused", locale=lang).format(title=feed_title)
+            )
+        case "resume":
+            await database.set_subscription_paused(chat_id, feed_id, False)
+            await message.reply(
+                i18n.t("bot.msg.rss.resumed", locale=lang).format(title=feed_title)
+            )
+
+
+async def _rss_interval(
+    message: _T.Message, chat_id: int, lang: str, command: list[str]
+) -> None:
+    """Set one subscription's poll interval; no minute argument = global default."""
+    subs = await database.get_chat_subscriptions(chat_id)
+    try:
+        index = int(command[2]) - 1
+        sub = subs[index]
+    except (ValueError, IndexError):
+        await message.reply(i18n.t("bot.msg.rss.invalid_index", locale=lang))
+        return
+
+    if len(command) < 4:
+        minutes = None
+    else:
+        try:
+            minutes = int(command[3])
+        except ValueError:
+            minutes = -1
+        if not (
+            database.MIN_SUBSCRIPTION_INTERVAL
+            <= minutes
+            <= database.MAX_SUBSCRIPTION_INTERVAL
+        ):
+            await message.reply(
+                i18n.t("bot.msg.rss.interval_invalid", locale=lang).format(
+                    min=database.MIN_SUBSCRIPTION_INTERVAL,
+                    max=database.MAX_SUBSCRIPTION_INTERVAL,
+                )
+            )
+            return
+
+    await database.set_subscription_interval(chat_id, sub.feed_id, minutes)
+    if minutes is None:
+        await message.reply(i18n.t("bot.msg.rss.interval_reset", locale=lang))
+    else:
+        await message.reply(
+            i18n.t("bot.msg.rss.interval_set", locale=lang).format(minutes=minutes)
+        )
+
+
+async def _rss_testpush(
+    client: PyrogramClient,
+    message: _T.Message,
+    chat_id: int,
+    user_id: int,
+    lang: str,
+    command: list[str],
+) -> None:
+    """Fetch one subscribed feed now and push its latest entries to this chat.
+
+    A manual "push now" for testing: unlike the poll job it ignores the seen
+    window (a feed with no new entries must still produce visible output), but
+    the pushed entries are marked seen so the next poll does not duplicate them.
+    """
+    subs = await database.get_chat_subscriptions(chat_id)
+    try:
+        index = int(command[2]) - 1
+        sub = subs[index]
+    except (ValueError, IndexError):
+        await message.reply(i18n.t("bot.msg.rss.invalid_index", locale=lang))
+        return
+
+    try:
+        _rss_add_limiter.check(f"{chat_id}:{user_id}")
+    except ApiError as e:
+        await message.reply(
+            i18n.t("bot.msg.rss.too_many_requests", locale=lang).format(error=e.message)
+        )
+        return
+
+    try:
+        result = await rss_service.fetch_feed(
+            sub.feed.url, etag=sub.feed.etag, last_modified=sub.feed.last_modified
+        )
+    except Exception as e:
+        await message.reply(
+            i18n.t("bot.msg.rss.fetch_failed", locale=lang).format(
+                error=e.__class__.__name__
+            )
+        )
+        logger.error(f"rss: testpush fetch failed for {redact_url(sub.feed.url)}: {e}")
+        return
+
+    pushed = 0
+    for entry in result.entries[: rss_service.MAX_ENTRIES_PER_PUSH]:
+        text = rss_service.render_entry(result.feed_title or sub.feed.url, entry, lang)
+        try:
+            if entry.media_urls:
+                await client.send_photo(
+                    chat_id,
+                    photo=entry.media_urls[0],
+                    caption=rss_service.truncate_for_delivery(text, 1024),
+                    parse_mode=pyrogram.enums.ParseMode.HTML,
+                )
+            else:
+                await client.send_message(
+                    chat_id,
+                    rss_service.truncate_for_delivery(text, 4096),
+                    parse_mode=pyrogram.enums.ParseMode.HTML,
+                    disable_web_page_preview=False,
+                )
+            pushed += 1
+        except Exception as e:
+            logger.error(f"rss: testpush send to {chat_id} failed: {e}")
+            break
+
+    await database.record_fetch_success(
+        sub.feed_id,
+        title=result.feed_title,
+        etag=result.etag,
+        last_modified=result.last_modified,
+        seen_entry_ids=[e.entry_id for e in result.entries],
+    )
+    await message.reply(
+        i18n.t("bot.msg.rss.testpush_done", locale=lang).format(count=pushed)
+    )

--- a/kmua/services/rss/__init__.py
+++ b/kmua/services/rss/__init__.py
@@ -1,0 +1,596 @@
+"""Fetch, parse, and render RSS/Atom feeds.
+
+Pure functions plus one async fetch — no Telegram or database access here, so the
+rendering and identity logic is unit-testable without a bot.
+
+Parsing is delegated to `feedparser`, which handles RSS 0.9x/1.0/2.0, Atom 0.3/1.0,
+encoding sniffing, and broken markup. It is a synchronous library, so `fetch_feed`
+runs `feedparser.parse` in a worker thread via `asyncio.to_thread` — the bot runs on
+a single event loop and a blocking parse would stall message handling. For the same
+reason the HTTP fetch is `httpx` async; feedparser's own fetch path uses blocking
+urllib and is never used.
+
+Feed content is untrusted remote data. There is no HTML sanitizer in this
+repository, so this module IS the sanitizer: `_sanitize_html` reduces entry HTML to
+the small tag set Telegram's HTML parse mode accepts (`b i u s blockquote code
+pre`), escapes everything else, and balances the tags — Telegram refuses a message
+with an unclosed entity. `render_entry` then emits that safe subset verbatim and
+escapes only the strings it builds itself. Images are not embedded in text
+(Telegram does not render `<img>`): they are extracted as URLs and delivered as a
+photo message by the caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import html
+import ipaddress
+import re
+import socket
+from dataclasses import dataclass, field
+from urllib.parse import urljoin, urlsplit
+
+import feedparser
+import httpx
+
+from kmua import i18n
+
+MAX_ENTRIES_PER_PUSH = 5
+"""Cap per feed per poll. A feed that just published 200 items must not turn into
+200 messages; the newest few are what a subscriber actually wants."""
+
+MAX_FAILURES = 10
+"""Consecutive failures after which a feed is skipped by the poll job."""
+
+_MAX_TITLE_LEN = 200
+_MAX_SUMMARY_LEN = 1024
+"""Long enough for a full-text entry excerpt; also Telegram's photo caption limit,
+so the same text fits either a text message or a photo caption."""
+_MAX_MEDIA = 3
+"""Images delivered per entry, at most. A gallery feed must not turn into ten
+separate photo messages per entry."""
+_MAX_BODY_BYTES = 5 * 1024 * 1024
+"""Largest response body we will parse. A giant feed must not eat the process."""
+
+_MAX_REDIRECTS = 5
+"""Redirect hops we will follow; each hop is re-validated against the address
+blocklist, so a public URL cannot tunnel into the internal network."""
+
+_USER_AGENT = "KMUA Bot"
+
+# Addresses a feed may never resolve to: private, loopback, link-local, CGNAT,
+# documentation, multicast and reserved ranges (IPv4), plus loopback/ULA/
+# link-local/multicast (IPv6). `ipaddress` covers most of these, but the ranges
+# here are spelled out so the blocklist does not depend on library version
+# semantics for the non-obvious ones.
+_NON_PUBLIC_V4 = [
+    ipaddress.ip_network(net)
+    for net in (
+        "0.0.0.0/8",
+        "10.0.0.0/8",
+        "100.64.0.0/10",
+        "127.0.0.0/8",
+        "169.254.0.0/16",
+        "172.16.0.0/12",
+        "192.0.0.0/24",
+        "192.0.2.0/24",
+        "192.168.0.0/16",
+        "198.18.0.0/15",
+        "198.51.100.0/24",
+        "203.0.113.0/24",
+        "224.0.0.0/4",
+        "240.0.0.0/4",
+    )
+]
+_NON_PUBLIC_V6 = [
+    ipaddress.ip_network(net)
+    for net in (
+        "::/128",
+        "::1/128",
+        "fc00::/7",
+        "fe80::/10",
+        "ff00::/8",
+    )
+]
+
+# The tag set Telegram's HTML parse mode renders, which `_sanitize_html` keeps.
+# It is the single source of truth: the kept-tag and token regexes are built
+# from it so a new kept tag cannot be added in one place and forgotten in the
+# other.
+_KEPT_TAGS = ("b", "i", "u", "s", "blockquote", "code", "pre")
+
+_KEPT_TAGS_ALT = "|".join(_KEPT_TAGS)
+# Matches exactly our own emitted tags (no attributes, no surprises).
+_KEPT_TAG_RE = re.compile(rf"</?({_KEPT_TAGS_ALT})>")
+# `\x01o<tag>\x01` / `\x01c<tag>\x01`: tags the sanitizer emitted itself, hidden
+# from the escape pass so source text cannot forge them. Inline formatting tags
+# only - code/pre blocks use the `\x00` placeholder path instead.
+_TAG_TOKEN_TAGS = "|".join(t for t in _KEPT_TAGS if t not in ("code", "pre"))
+_TAG_TOKEN_RE = re.compile(rf"\x01([oc])({_TAG_TOKEN_TAGS})\x01")
+
+# Block-level closing tags become paragraph breaks so the pushed text keeps the
+# source layout instead of collapsing into one blob.
+_BLOCK_CLOSE_RE = re.compile(
+    r"</(?:p|div|li|h[1-6]|figure|figcaption|blockquote|tr|article|section|ul|ol|table|pre)>",
+    re.IGNORECASE,
+)
+_BR_RE = re.compile(r"<br\s*/?>", re.IGNORECASE)
+_TAG_RE = re.compile(r"<[^>]+>")
+_IMG_SRC_RE = re.compile(r"<img[^>]+src=[\"']([^\"']+)[\"']", re.IGNORECASE)
+_SPACES_RE = re.compile(r"[ \t\xa0]+")
+# `<pre>`/`<code>` blocks are protected verbatim (their content escaped) so code
+# survives the tag-stripping pass intact.
+_PRE_CODE_RE = re.compile(r"<(pre|code)\b[^>]*>(.*?)</\1>", re.IGNORECASE | re.DOTALL)
+_INLINE_TAG_RE = re.compile(
+    r"</?(strong|b|em|i|u|ins|s|strike|del|blockquote|a|[a-z][a-z0-9]*)\b[^>]*>",
+    re.IGNORECASE,
+)
+_PLACEHOLDER_RE = re.compile(r"\x00(\d+)\x00")
+_CTRL_ENTITY_RE = re.compile(r"&#(?:x[0-9a-fA-F]{1,6}|\d{1,7});?")
+
+_ENTITY_TO_TAG = {
+    "strong": "b",
+    "em": "i",
+    "strike": "s",
+    "del": "s",
+    "ins": "u",
+}
+
+
+@dataclass(slots=True)
+class FeedEntry:
+    entry_id: str
+    title: str
+    link: str
+    summary: str
+    media_urls: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class FetchResult:
+    """Outcome of one poll. `not_modified` means a 304 — nothing to do."""
+
+    not_modified: bool
+    feed_title: str | None
+    entries: list[FeedEntry]
+    etag: str | None
+    last_modified: str | None
+
+
+def _plain_text(raw: str, limit: int) -> str:
+    """Entry HTML reduced to plain text with paragraph breaks.
+
+    Used for titles, where markup is noise. Block tags become blank lines,
+    `<br>` a line break; everything else is stripped and entities unescaped.
+    """
+    text = raw or ""
+    text = _BR_RE.sub("\n", text)
+    text = _BLOCK_CLOSE_RE.sub("\n\n", text)
+    text = _TAG_RE.sub("", text)
+    text = html.unescape(text)
+    return _collapse_lines(text)[:limit]
+
+
+def _collapse_lines(text: str) -> str:
+    """Trim each line, keep at most one blank line between paragraphs, and
+    collapse runs of spaces (not newlines)."""
+    lines = [line.strip() for line in text.split("\n")]
+    out: list[str] = []
+    for line in lines:
+        if not line:
+            if out and out[-1]:
+                out.append("")
+            continue
+        out.append(line)
+    collapsed = "\n".join(out).strip("\n")
+    return _SPACES_RE.sub(" ", collapsed)
+
+
+def _escape_text_parts(text: str) -> str:
+    """Escape everything, then restore the tags the sanitizer emitted itself.
+
+    The kept tags are hidden behind `\x01` tokens during unescape + escape, so a
+    literal `&lt;b&gt;` in the source (unescaped to `<b>`) is escaped back to
+    text while our own tags come back untouched.
+    """
+    escaped = html.escape(text, quote=False)
+    return _TAG_TOKEN_RE.sub(
+        lambda m: f"{'</' if m.group(1) == 'c' else '<'}{m.group(2)}>", escaped
+    )
+
+
+def _balance_tags(text: str) -> str:
+    """Drop tags that do not close, so Telegram never sees an unclosed entity.
+
+    Operates only on the kept tag set; the content of a dropped tag is kept.
+    """
+    out: list[str] = []
+    stack: list[tuple[str, int]] = []
+    pos = 0
+    for match in _KEPT_TAG_RE.finditer(text):
+        out.append(text[pos : match.start()])
+        token = match.group(0)
+        name = match.group(1).lower()
+        if token.startswith("</"):
+            if stack and stack[-1][0] == name:
+                stack.pop()
+                out.append(f"</{name}>")
+            # Stray closing tag: dropped with its text kept.
+        else:
+            stack.append((name, len(out)))
+            out.append(f"<{name}>")
+        pos = match.end()
+    out.append(text[pos:])
+    for _, index in stack:
+        out[index] = ""
+    return "".join(out)
+
+
+def _strip_ctrl_entities(text: str) -> str:
+    """Remove numeric character references that decode to control characters.
+
+    `html.unescape` turns `&#1;` into a literal `\x01`; that byte is the
+    sanitizer's own tag-token sentinel, so a feed could forge a token and have
+    it restored as a real tag. Control characters are meaningless in feed text,
+    so their entity forms are dropped before the unescape pass instead of
+    special-casing the sentinels.
+    """
+
+    def repl(match: re.Match) -> str:
+        raw = match.group(0)
+        digits = raw[2:-1] if raw.endswith(";") else raw[2:]
+        try:
+            codepoint = int(digits, 16) if digits[:1].lower() == "x" else int(digits)
+        except ValueError:
+            return raw
+        if codepoint <= 0x20 or 0x7F <= codepoint <= 0x9F:
+            return ""
+        return raw
+
+    return _CTRL_ENTITY_RE.sub(repl, text)
+
+
+def _sanitize_html(raw: str, limit: int) -> str:
+    """Reduce entry HTML to the Telegram-safe tag subset.
+
+    Keeps `b i u s blockquote code pre` (with strong/em/strike/del/ins mapped),
+    preserves paragraph breaks, escapes everything else, and balances the tags.
+    The result is safe to emit verbatim with `parse_mode=HTML`.
+    """
+    text = raw or ""
+
+    # 1. Protect code blocks so their content (which may contain tags, `<` or
+    #    newlines) survives the passes below untouched and escaped.
+    placeholders: list[str] = []
+
+    def protect(match: re.Match) -> str:
+        tag = match.group(1).lower()
+        body = match.group(2)
+        # `<pre><code class="language-x">…</code></pre>` is the common wrapper on
+        # real feeds; strip the inner code tags (and their attributes) so the
+        # label text never shows up inside the rendered block.
+        body = re.sub(r"</?code\b[^>]*>", "", body, flags=re.IGNORECASE)
+        # `<br>` inside a block is a line break, not literal text.
+        body = _BR_RE.sub("\n", body)
+        # Unescape once before escaping: feeds frequently ship pre-escaped code
+        # (`&lt;` for `<`), and escaping the entity would double-escape it.
+        body = html.escape(html.unescape(body), quote=False)
+        placeholders.append(f"<{tag}>{body}</{tag}>")
+        return f"\x00{len(placeholders) - 1}\x00"
+
+    text = _PRE_CODE_RE.sub(protect, text)
+
+    # 1b. Drop control-character entities before unescape so they cannot forge
+    #     the sentinels below; then line/paragraph structure.
+    text = _strip_ctrl_entities(text)
+
+    # 2. Line/paragraph structure; HTML comments are noise, not content.
+    text = re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+    text = _BR_RE.sub("\n", text)
+    text = _BLOCK_CLOSE_RE.sub("\n\n", text)
+
+    # 3. One pass over every tag: inline formatting tags map onto the kept set
+    #    (hidden behind \x01 tokens for now), everything else (anchors, images,
+    #    scripts, ...) is dropped with its visible text kept.
+    def inline(match: re.Match) -> str:
+        token = match.group(0)
+        closing = token.startswith("</")
+        name = _ENTITY_TO_TAG.get(match.group(1).lower(), match.group(1).lower())
+        if name not in {"b", "i", "u", "s", "blockquote"}:
+            return ""
+        return f"\x01{'c' if closing else 'o'}{name}\x01"
+
+    text = _INLINE_TAG_RE.sub(inline, text)
+
+    # 4. Unescape, then re-escape everything that is not one of our tags.
+    text = _escape_text_parts(html.unescape(text))
+
+    # 5. Collapse layout.
+    text = _collapse_lines(text)
+
+    # 6. Truncate; a cut through a placeholder drops that code block entirely
+    #    rather than emitting a broken one. Placeholder indices from source text
+    #    (a literal NUL byte cannot be decoded from an entity, but be safe) are
+    #    bounds-checked so a forged index cannot crash the fetch.
+    text = text[:limit]
+
+    def restore(match: re.Match) -> str:
+        index = int(match.group(1))
+        if 0 <= index < len(placeholders):
+            return placeholders[index]
+        return ""
+
+    text = _PLACEHOLDER_RE.sub(restore, text)
+    text = re.sub(r"\x00\d*\x00?", "", text)
+
+    # 7. Balance.
+    return _balance_tags(text)
+
+
+def _entry_html(raw_entry) -> str:
+    """The richest HTML body an entry carries: content, else summary/description.
+
+    `content` is the full article on real-world feeds (content:encoded, Atom
+    content); summary/description is often just an excerpt or even the bare title.
+    """
+    html_parts = "".join(
+        c.get("value", "") or "" for c in raw_entry.get("content") or []
+    )
+    if html_parts:
+        return html_parts
+    return raw_entry.get("summary") or raw_entry.get("description") or ""
+
+
+def _extract_media(raw_html: str, raw_entry, base: str) -> list[str]:
+    """Image URLs for one entry: `<img>` in the body, then enclosures.
+
+    Relative URLs are resolved against the feed's own base. Only http(s) URLs are
+    kept - Telegram's photo-by-URL path accepts https (and http is refused by
+    Telegram), and data: URIs cannot be pushed at all.
+    """
+    urls: list[str] = []
+    for src in _IMG_SRC_RE.findall(raw_html or ""):
+        urls.append(urljoin(base, src))
+    for enc in raw_entry.get("enclosures") or []:
+        if str(enc.get("type", "")).startswith("image/"):
+            urls.append(urljoin(base, enc.get("url", "")))
+    for media in raw_entry.get("media_content") or []:
+        if str(media.get("type", "")).startswith("image/"):
+            urls.append(urljoin(base, media.get("url", "")))
+    for thumb in raw_entry.get("media_thumbnail") or []:
+        urls.append(urljoin(base, thumb.get("url", "")))
+
+    seen: list[str] = []
+    for url in urls:
+        if url.startswith(("http://", "https://")) and url not in seen:
+            seen.append(url)
+        if len(seen) >= _MAX_MEDIA:
+            break
+    return seen
+
+
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """True when `ip` may not be contacted by the fetcher."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    networks = (
+        _NON_PUBLIC_V4 if isinstance(ip, ipaddress.IPv4Address) else _NON_PUBLIC_V6
+    )
+    return any(ip in net for net in networks)
+
+
+async def _validate_url(url: str) -> None:
+    """Reject URLs that would reach anything but a public internet address.
+
+    Resolves the host and refuses the fetch when any address is private,
+    loopback, link-local, CGNAT, metadata (169.254.0.0/16 covers the cloud
+    metadata endpoint), or otherwise non-routable. This is the SSRF guard: it
+    runs on the original URL and on every redirect hop.
+    """
+    parsed = urlsplit(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"unsupported scheme: {parsed.scheme!r}")
+    if parsed.username is not None or parsed.password is not None:
+        # A signed feed URL would otherwise leak its credentials into logs and
+        # error stores; refuse rather than redact-by-accident.
+        raise ValueError("feed URLs may not carry credentials")
+    host = parsed.hostname
+    if not host:
+        raise ValueError("feed URL has no host")
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError:
+        raise ValueError("feed URL has an invalid port")
+    infos = await asyncio.to_thread(
+        socket.getaddrinfo, host, port, type=socket.SOCK_STREAM
+    )
+    if not infos:
+        raise ValueError("feed host does not resolve")
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if _is_blocked_ip(ip):
+            raise ValueError(f"feed host resolves to a non-public address: {ip}")
+
+
+def redact_url(url: str) -> str:
+    """Strip query, fragment and userinfo from a URL for logs and error stores.
+
+    A signed feed URL (`?token=...`) must not have its secret persisted into
+    logs, the audit trail, or `last_error`; the feed row itself keeps the raw
+    URL because fetching needs it.
+    """
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return "<invalid url>"
+    if parsed.scheme not in ("http", "https"):
+        return url
+    host = parsed.hostname or ""
+    try:
+        if parsed.port:
+            host = f"{host}:{parsed.port}"
+    except ValueError:
+        pass
+    return f"{parsed.scheme}://{host}{parsed.path}"
+
+
+async def fetch_feed(
+    url: str, *, etag: str | None = None, last_modified: str | None = None
+) -> FetchResult:
+    """Fetch and parse one feed.
+
+    Raises `httpx.HTTPError` / `ValueError` on failure; the caller records it.
+    The body is streamed and aborted past `_MAX_BODY_BYTES` rather than buffered
+    whole first. Redirects are followed by hand, re-validating each hop against
+    the address blocklist (a public URL must not tunnel into the internal
+    network).
+    """
+    headers = {"User-Agent": _USER_AGENT}
+    if etag:
+        headers["If-None-Match"] = etag
+    if last_modified:
+        headers["If-Modified-Since"] = last_modified
+
+    async with httpx.AsyncClient(
+        timeout=httpx.Timeout(30, connect=10),
+        follow_redirects=False,
+        headers=headers,
+    ) as client:
+        current = url
+        content: bytes = b""
+        for _ in range(_MAX_REDIRECTS + 1):
+            await _validate_url(current)
+            async with client.stream("GET", current) as resp:
+                if resp.status_code in (301, 302, 303, 307, 308):
+                    location = resp.headers.get("location")
+                    if not location:
+                        break
+                    current = urljoin(current, location)
+                    continue
+                if resp.status_code == 304:
+                    return FetchResult(
+                        not_modified=True,
+                        feed_title=None,
+                        entries=[],
+                        etag=etag,
+                        last_modified=last_modified,
+                    )
+                resp.raise_for_status()
+
+                chunks: list[bytes] = []
+                size = 0
+                async for chunk in resp.aiter_bytes():
+                    chunks.append(chunk)
+                    size += len(chunk)
+                    if size > _MAX_BODY_BYTES:
+                        raise ValueError("feed too large")
+                content = b"".join(chunks)
+                break
+        else:
+            raise ValueError("too many redirects")
+
+    parsed = await asyncio.to_thread(feedparser.parse, content)
+
+    if parsed.bozo and not parsed.entries:
+        raise ValueError(f"malformed feed: {parsed.get('bozo_exception')}")
+
+    # Base for resolving relative entry links and image srcs. Many feeds use
+    # absolute URLs, but relative ones are common enough (e.g. `/artwork/...`)
+    # that pushing a broken link is a real outcome without this.
+    feed_link = parsed.feed.get("link") or "" if parsed.feed else ""
+    base = feed_link if feed_link.startswith(("http://", "https://")) else url
+
+    entries = []
+    for raw in parsed.entries[: MAX_ENTRIES_PER_PUSH * 4]:
+        link = urljoin(base, raw.get("link", "") or "")
+        if not link.startswith(("http://", "https://")):
+            # An entry link of another scheme would land in the message's href
+            # verbatim; drop it rather than emit a javascript:/data: link.
+            link = ""
+        entries.append(
+            FeedEntry(
+                entry_id=entry_id_of(raw),
+                title=_plain_text(raw.get("title", ""), _MAX_TITLE_LEN),
+                link=link,
+                summary=_sanitize_html(_entry_html(raw), _MAX_SUMMARY_LEN),
+                media_urls=_extract_media(_entry_html(raw), raw, base),
+            )
+        )
+
+    return FetchResult(
+        not_modified=False,
+        feed_title=(parsed.feed.get("title") or None) if parsed.feed else None,
+        entries=entries,
+        etag=resp.headers.get("ETag"),
+        last_modified=resp.headers.get("Last-Modified"),
+    )
+
+
+def entry_id_of(raw_entry) -> str:
+    """Stable identity for an entry: `id`, else `link`, else a sha256 of title+summary.
+
+    A feed with neither id nor link is rare but real; hashing the content keeps such a
+    feed from re-pushing every single poll.
+    """
+    entry_id = raw_entry.get("id") or raw_entry.get("link")
+    if entry_id:
+        return str(entry_id)
+    digest = hashlib.sha256()
+    digest.update(str(raw_entry.get("title", "")).encode("utf-8", "replace"))
+    digest.update(b"\0")
+    digest.update(str(raw_entry.get("summary", "")).encode("utf-8", "replace"))
+    return digest.hexdigest()
+
+
+def render_entry(feed_title: str, entry: FeedEntry, lang: str) -> str:
+    """Build the HTML message body for one entry.
+
+    `entry.summary` is already restricted to the safe tag set by `_sanitize_html`
+    and is emitted verbatim; every other remote string is escaped here.
+    """
+    title = entry.title or i18n.t("bot.msg.rss.untitled", locale=lang)
+    escaped_title = html.escape(title)
+    escaped_feed_title = html.escape(feed_title)
+
+    lines = [f"📰 <b>{escaped_feed_title}</b>"]
+    if entry.link:
+        lines.append(f'<a href="{html.escape(entry.link)}">{escaped_title}</a>')
+    else:
+        lines.append(f"<b>{escaped_title}</b>")
+    if entry.summary:
+        lines.append("")
+        lines.append(entry.summary)
+    return "\n".join(lines)
+
+
+def truncate_for_delivery(text: str, limit: int) -> str:
+    """Shrink a rendered message to fit `limit` without breaking HTML.
+
+    Prefers a paragraph boundary (blank line), then a line break, then a bare
+    character cut. The result is re-balanced so Telegram never sees an unclosed
+    entity, and an ellipsis is appended when anything was dropped.
+    """
+    if len(text) <= limit:
+        return text
+    head = text[:limit]
+    cut = head.rfind("\n\n")
+    if cut < limit // 2:
+        cut = head.rfind("\n")
+    if cut < limit // 2:
+        cut = limit
+    snippet = text[:cut].rstrip()
+    return _balance_tags(snippet) + " …"
+
+
+__all__ = [
+    "MAX_ENTRIES_PER_PUSH",
+    "MAX_FAILURES",
+    "FeedEntry",
+    "FetchResult",
+    "entry_id_of",
+    "redact_url",
+    "fetch_feed",
+    "render_entry",
+    "truncate_for_delivery",
+]

--- a/kmua/webapp/routers/admin.py
+++ b/kmua/webapp/routers/admin.py
@@ -82,7 +82,7 @@ async def read_stats(user: RequireAdmin) -> StatsOut:
             "api_requests": snapshot.api_requests,
             "api_latency_ms": snapshot.api_latency_ms,
         },
-        dashboard=dashboard, 
+        dashboard=dashboard,
     )
 
 
@@ -397,6 +397,7 @@ async def read_chat_policies(user: RequireAdmin) -> ChatPolicyListOut:
     rows = await database.get_chat_policies()
     return ChatPolicyListOut(
         agent_whitelist_mode=app_config.agent_whitelist_mode,
+        rss_whitelist_mode=app_config.rss_whitelist_mode,
         items=[
             ChatPolicyOut(
                 chat_id=row.chat_id,
@@ -439,7 +440,10 @@ async def write_chat_policy(
             current.agent_allowed
             if payload.agent_allowed is None
             else payload.agent_allowed
-        )
+        ),
+        rss_allowed=(
+            current.rss_allowed if payload.rss_allowed is None else payload.rss_allowed
+        ),
     )
 
     old, new = await database.set_chat_policy(

--- a/kmua/webapp/routers/chats.py
+++ b/kmua/webapp/routers/chats.py
@@ -14,9 +14,11 @@ from kmua.common import ops
 from kmua.config import app_config
 from kmua.database.models import ChatConfig
 from kmua.logger import logger
+from kmua.services import rss as rss_service
+from kmua.services.rss import redact_url
 from kmua.webapp import audit
 from kmua.webapp.deps import ChatAdminCtx, client_key
-from kmua.webapp.errors import ApiError, ErrorCode, not_found
+from kmua.webapp.errors import ApiError, ErrorCode, forbidden, not_found
 from kmua.webapp.ratelimit import write_limiter
 from kmua.webapp.schemas import (
     TITLE_PERMISSION_KEYS,
@@ -27,10 +29,13 @@ from kmua.webapp.schemas import (
     ChatDetailOut,
     PageOut,
     QuoteOut,
+    RssSubscriptionIn,
+    RssSubscriptionOut,
+    RssSubscriptionPatch,
     SyncMembersOut,
     TitlePermissionsIn,
 )
-from kmua.webapp.serializers import chat_config_out, quote_out
+from kmua.webapp.serializers import chat_config_out, quote_out, rss_subscription_out
 
 router = APIRouter(prefix="/api/chats", tags=["chats"])
 
@@ -244,9 +249,7 @@ async def sync_members(request: Request, ctx: ChatAdminCtx) -> SyncMembersOut:
     cooldown_key = f"sync_members:{ctx.chat.id}"
     if await common.memttlcache.get(cooldown_key):
         raise ApiError(ErrorCode.COOLDOWN, "Members were synced recently")
-    await common.memttlcache.set(
-        cooldown_key, True, app_config.cachettl_sync_members
-    )
+    await common.memttlcache.set(cooldown_key, True, app_config.cachettl_sync_members)
 
     try:
         result = await ops.sync_chat_members(ctx.chat.id)
@@ -309,4 +312,155 @@ async def delete_chat_quote(
         actor_roles=ctx.user.roles,
         target=f"{ctx.chat.id}",
         extra={"link": link},
+    )
+
+
+# ------------------------------------------------------------------ rss
+
+
+@router.get("/{chat_id}/rss", response_model=PageOut[RssSubscriptionOut])
+async def list_chat_rss(
+    ctx: ChatAdminCtx,
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+) -> PageOut[RssSubscriptionOut]:
+    if not app_config.rss_enabled:
+        raise ApiError(ErrorCode.FEATURE_DISABLED, "RSS is disabled")
+    if not await database.is_rss_allowed(ctx.chat.id):
+        raise forbidden(ErrorCode.FORBIDDEN, "RSS is not enabled for this chat")
+
+    result = await database.get_chat_subscriptions_paged(
+        ctx.chat.id, page=page, size=size
+    )
+    return PageOut[RssSubscriptionOut](
+        items=[rss_subscription_out(sub) for sub in result.items],
+        total=result.total,
+        page=result.page,
+        size=result.size,
+    )
+
+
+@router.post("/{chat_id}/rss", response_model=RssSubscriptionOut, status_code=201)
+async def add_chat_rss(
+    request: Request, ctx: ChatAdminCtx, payload: RssSubscriptionIn
+) -> RssSubscriptionOut:
+    if not app_config.rss_enabled:
+        raise ApiError(ErrorCode.FEATURE_DISABLED, "RSS is disabled")
+    if not await database.is_rss_allowed(ctx.chat.id):
+        raise forbidden(ErrorCode.FORBIDDEN, "RSS is not enabled for this chat")
+    write_limiter.check(client_key(request, ctx.user.id))
+
+    url = payload.url.strip()
+    if not url.startswith(("http://", "https://")):
+        raise ApiError(ErrorCode.VALIDATION_FAILED, "URL must be http(s)")
+
+    # Validate synchronously: subscribing to a URL that cannot be fetched would
+    # otherwise be a silent never-pushing subscription.
+    try:
+        result = await rss_service.fetch_feed(url)
+    except Exception as e:
+        raise ApiError(
+            ErrorCode.VALIDATION_FAILED, f"Feed unreachable: {e.__class__.__name__}"
+        )
+
+    sub, reason = await database.add_subscription(
+        ctx.chat.id, url, created_by=ctx.user.id
+    )
+    if sub is None:
+        if reason == "already_subscribed":
+            raise ApiError(ErrorCode.CONFLICT, "Already subscribed", 409)
+        raise ApiError(ErrorCode.CONFLICT, "Subscription limit reached", 409)
+
+    # Seed the seen window immediately, matching the command path and the poll
+    # job's first-fetch rule: no history flood on the next poll.
+    await database.record_fetch_success(
+        sub.feed_id,
+        title=result.feed_title,
+        etag=result.etag,
+        last_modified=result.last_modified,
+        seen_entry_ids=[e.entry_id for e in result.entries],
+    )
+
+    # The response reflects the fetch we just recorded, so re-read with the feed
+    # joined rather than serializing the pre-fetch snapshot.
+    fresh = next(
+        s
+        for s in await database.get_chat_subscriptions(ctx.chat.id)
+        if s.feed_id == sub.feed_id
+    )
+
+    audit.record(
+        action="chat.rss.add",
+        actor_id=ctx.user.id,
+        actor_roles=ctx.user.roles,
+        target=f"{ctx.chat.id}",
+        extra={"url": redact_url(url)},
+    )
+    return rss_subscription_out(fresh)
+
+
+@router.patch("/{chat_id}/rss/{feed_id}", response_model=list[RssSubscriptionOut])
+async def update_chat_rss(
+    request: Request,
+    ctx: ChatAdminCtx,
+    payload: RssSubscriptionPatch,
+    feed_id: int = Path(description="Feed the subscription points at"),
+) -> list[RssSubscriptionOut]:
+    if not app_config.rss_enabled:
+        raise ApiError(ErrorCode.FEATURE_DISABLED, "RSS is disabled")
+    if not await database.is_rss_allowed(ctx.chat.id):
+        raise forbidden(ErrorCode.FORBIDDEN, "RSS is not enabled for this chat")
+    write_limiter.check(client_key(request, ctx.user.id))
+
+    fields = payload.model_fields_set
+    updated = False
+    if "paused" in fields and payload.paused is not None:
+        updated = (
+            await database.set_subscription_paused(ctx.chat.id, feed_id, payload.paused)
+            or updated
+        )
+    if "interval_minutes" in fields:
+        updated = (
+            await database.set_subscription_interval(
+                ctx.chat.id, feed_id, payload.interval_minutes
+            )
+            or updated
+        )
+    if not updated:
+        raise not_found(ErrorCode.NOT_FOUND, "Subscription not found")
+
+    audit.record(
+        action="chat.rss.update",
+        actor_id=ctx.user.id,
+        actor_roles=ctx.user.roles,
+        target=f"{ctx.chat.id}",
+        extra={"feed_id": feed_id, "paused": payload.paused},
+    )
+    # Return the whole list, matching the other chat-level write endpoints: the
+    # frontend gets the server's actual state instead of reconciling itself.
+    subs = await database.get_chat_subscriptions(ctx.chat.id)
+    return [rss_subscription_out(sub) for sub in subs]
+
+
+@router.delete("/{chat_id}/rss/{feed_id}", status_code=204)
+async def delete_chat_rss(
+    request: Request,
+    ctx: ChatAdminCtx,
+    feed_id: int = Path(description="Feed the subscription points at"),
+) -> None:
+    if not app_config.rss_enabled:
+        raise ApiError(ErrorCode.FEATURE_DISABLED, "RSS is disabled")
+    if not await database.is_rss_allowed(ctx.chat.id):
+        raise forbidden(ErrorCode.FORBIDDEN, "RSS is not enabled for this chat")
+    write_limiter.check(client_key(request, ctx.user.id))
+
+    if not await database.remove_subscription(ctx.chat.id, feed_id):
+        raise not_found(ErrorCode.NOT_FOUND, "Subscription not found")
+
+    audit.record(
+        action="chat.rss.delete",
+        actor_id=ctx.user.id,
+        actor_roles=ctx.user.roles,
+        target=f"{ctx.chat.id}",
+        extra={"feed_id": feed_id},
     )

--- a/kmua/webapp/routers/me.py
+++ b/kmua/webapp/routers/me.py
@@ -16,12 +16,16 @@ from pyrogram.enums import ParseMode
 from kmua import common, database
 from kmua.bot.client import client
 from kmua.common import ops
+from kmua.config import app_config
 from kmua.gift import define as gift_define
 from kmua.gift.service import send_gift_to_bot
 from kmua.i18n import i18n
 from kmua.logger import logger
+from kmua.services import rss as rss_service
+from kmua.services.rss import redact_url
+from kmua.webapp import audit
 from kmua.webapp.deps import CurrentUser, client_key
-from kmua.webapp.errors import ApiError, ErrorCode, not_found
+from kmua.webapp.errors import ApiError, ErrorCode, forbidden, not_found
 from kmua.webapp.ratelimit import write_limiter
 from kmua.webapp.schemas import (
     ChatBriefOut,
@@ -33,10 +37,13 @@ from kmua.webapp.schemas import (
     MeOut,
     PageOut,
     QuoteOut,
+    RssSubscriptionIn,
+    RssSubscriptionOut,
+    RssSubscriptionPatch,
     WaifuEntryOut,
     WaifuOut,
 )
-from kmua.webapp.serializers import quote_out, timestamp
+from kmua.webapp.serializers import quote_out, rss_subscription_out, timestamp
 
 router = APIRouter(prefix="/api/me", tags=["me"])
 
@@ -171,6 +178,150 @@ async def delete_my_quote(
     if quote.user_id != user.id:
         raise not_found(ErrorCode.QUOTE_NOT_FOUND, "Quote not found")
     await database.delete_quote(link)
+
+
+# ------------------------------------------------------------------ rss
+
+# A user's private chat with the bot IS the user's id, so the personal RSS
+# endpoints are the group endpoints applied to `user.id` as the chat. The gates
+# are identical (feature switch + whitelist policy); the subscription CRUD is
+# shared.
+
+
+@router.get("/rss", response_model=PageOut[RssSubscriptionOut])
+async def list_my_rss(
+    user: CurrentUser,
+    page: int = Query(1, ge=1),
+    size: int = Query(20, ge=1, le=100),
+) -> PageOut[RssSubscriptionOut]:
+    if not app_config.rss_enabled:
+        raise ApiError(ErrorCode.FEATURE_DISABLED, "RSS is disabled")
+    if not await database.is_rss_allowed(user.id):
+        raise forbidden(ErrorCode.FORBIDDEN, "RSS is not enabled for this chat")
+
+    result = await database.get_chat_subscriptions_paged(user.id, page=page, size=size)
+    return PageOut[RssSubscriptionOut](
+        items=[rss_subscription_out(sub) for sub in result.items],
+        total=result.total,
+        page=result.page,
+        size=result.size,
+    )
+
+
+@router.post("/rss", response_model=RssSubscriptionOut, status_code=201)
+async def add_my_rss(
+    request: Request, user: CurrentUser, payload: RssSubscriptionIn
+) -> RssSubscriptionOut:
+    if not app_config.rss_enabled:
+        raise ApiError(ErrorCode.FEATURE_DISABLED, "RSS is disabled")
+    if not await database.is_rss_allowed(user.id):
+        raise forbidden(ErrorCode.FORBIDDEN, "RSS is not enabled for this chat")
+    write_limiter.check(client_key(request, user.id))
+
+    url = payload.url.strip()
+    if not url.startswith(("http://", "https://")):
+        raise ApiError(ErrorCode.VALIDATION_FAILED, "URL must be http(s)")
+
+    try:
+        result = await rss_service.fetch_feed(url)
+    except Exception as e:
+        raise ApiError(
+            ErrorCode.VALIDATION_FAILED, f"Feed unreachable: {e.__class__.__name__}"
+        )
+
+    sub, reason = await database.add_subscription(user.id, url, created_by=user.id)
+    if sub is None:
+        if reason == "already_subscribed":
+            raise ApiError(ErrorCode.CONFLICT, "Already subscribed", 409)
+        raise ApiError(ErrorCode.CONFLICT, "Subscription limit reached", 409)
+
+    await database.record_fetch_success(
+        sub.feed_id,
+        title=result.feed_title,
+        etag=result.etag,
+        last_modified=result.last_modified,
+        seen_entry_ids=[e.entry_id for e in result.entries],
+    )
+
+    fresh = next(
+        s
+        for s in await database.get_chat_subscriptions(user.id)
+        if s.feed_id == sub.feed_id
+    )
+
+    audit.record(
+        action="me.rss.add",
+        actor_id=user.id,
+        actor_roles=user.roles,
+        target=f"{user.id}",
+        extra={"url": redact_url(url)},
+    )
+    return rss_subscription_out(fresh)
+
+
+@router.patch("/rss/{feed_id}", response_model=list[RssSubscriptionOut])
+async def update_my_rss(
+    request: Request,
+    user: CurrentUser,
+    payload: RssSubscriptionPatch,
+    feed_id: int = Path(description="Feed the subscription points at"),
+) -> list[RssSubscriptionOut]:
+    if not app_config.rss_enabled:
+        raise ApiError(ErrorCode.FEATURE_DISABLED, "RSS is disabled")
+    if not await database.is_rss_allowed(user.id):
+        raise forbidden(ErrorCode.FORBIDDEN, "RSS is not enabled for this chat")
+    write_limiter.check(client_key(request, user.id))
+
+    fields = payload.model_fields_set
+    updated = False
+    if "paused" in fields and payload.paused is not None:
+        updated = (
+            await database.set_subscription_paused(user.id, feed_id, payload.paused)
+            or updated
+        )
+    if "interval_minutes" in fields:
+        updated = (
+            await database.set_subscription_interval(
+                user.id, feed_id, payload.interval_minutes
+            )
+            or updated
+        )
+    if not updated:
+        raise not_found(ErrorCode.NOT_FOUND, "Subscription not found")
+
+    audit.record(
+        action="me.rss.update",
+        actor_id=user.id,
+        actor_roles=user.roles,
+        target=f"{user.id}",
+        extra={"feed_id": feed_id, "paused": payload.paused},
+    )
+    subs = await database.get_chat_subscriptions(user.id)
+    return [rss_subscription_out(sub) for sub in subs]
+
+
+@router.delete("/rss/{feed_id}", status_code=204)
+async def delete_my_rss(
+    request: Request,
+    user: CurrentUser,
+    feed_id: int = Path(description="Feed the subscription points at"),
+) -> None:
+    if not app_config.rss_enabled:
+        raise ApiError(ErrorCode.FEATURE_DISABLED, "RSS is disabled")
+    if not await database.is_rss_allowed(user.id):
+        raise forbidden(ErrorCode.FORBIDDEN, "RSS is not enabled for this chat")
+    write_limiter.check(client_key(request, user.id))
+
+    if not await database.remove_subscription(user.id, feed_id):
+        raise not_found(ErrorCode.NOT_FOUND, "Subscription not found")
+
+    audit.record(
+        action="me.rss.delete",
+        actor_id=user.id,
+        actor_roles=user.roles,
+        target=f"{user.id}",
+        extra={"feed_id": feed_id},
+    )
 
 
 @router.get("/waifu", response_model=WaifuOut)

--- a/kmua/webapp/schemas.py
+++ b/kmua/webapp/schemas.py
@@ -272,6 +272,32 @@ class SyncMembersOut(ApiModel):
     checked: int
 
 
+class RssSubscriptionOut(ApiModel):
+    id: int
+    feed_id: int
+    url: str
+    title: str | None
+    paused: bool
+    # None means the subscription follows the global rss_interval.
+    interval_minutes: int | None
+    last_error: str | None
+    last_fetched_at: str
+    created_at: str
+
+
+class RssSubscriptionIn(ApiModel):
+    url: str = Field(min_length=1, max_length=1024)
+
+
+class RssSubscriptionPatch(ApiModel):
+    """A subscription write. Absent fields keep their current value."""
+
+    paused: bool | None = None
+    interval_minutes: int | None = Field(
+        default=None, ge=1, le=1440, description="Minutes; null = global default"
+    )
+
+
 # -------------------------------------------------------------------------- admin
 
 
@@ -388,6 +414,7 @@ class ChatPolicyFlagsOut(ApiModel):
     """
 
     agent_allowed: bool
+    rss_allowed: bool
 
 
 class ChatPolicyOut(ApiModel):
@@ -409,6 +436,7 @@ class ChatPolicyListOut(ApiModel):
     """
 
     agent_whitelist_mode: bool
+    rss_whitelist_mode: bool
     items: list[ChatPolicyOut]
 
 
@@ -416,6 +444,7 @@ class ChatPolicyIn(ApiModel):
     """A policy write. Absent flags keep their current value."""
 
     agent_allowed: bool | None = None
+    rss_allowed: bool | None = None
     note: str | None = Field(default=None, max_length=256)
 
 

--- a/kmua/webapp/serializers.py
+++ b/kmua/webapp/serializers.py
@@ -9,12 +9,19 @@ from __future__ import annotations
 from datetime import datetime
 
 from kmua.config import app_config
-from kmua.database.models import ChatConfig, ChatData, Quote, UserData
+from kmua.database.models import (
+    ChatConfig,
+    ChatData,
+    Quote,
+    RssSubscription,
+    UserData,
+)
 from kmua.webapp.schemas import (
     AdminChatOut,
     AdminUserOut,
     ChatConfigOut,
     QuoteOut,
+    RssSubscriptionOut,
 )
 
 
@@ -116,4 +123,18 @@ def admin_user_out(user: UserData) -> AdminUserOut:
         is_married=user.is_married,
         married_waifu_id=user.married_waifu_id,
         created_at=timestamp(user.created_at),
+    )
+
+
+def rss_subscription_out(sub: RssSubscription) -> RssSubscriptionOut:
+    return RssSubscriptionOut(
+        id=sub.id,
+        feed_id=sub.feed_id,
+        url=sub.feed.url,
+        title=sub.feed.title,
+        paused=sub.paused,
+        interval_minutes=sub.interval_minutes,
+        last_error=sub.feed.last_error,
+        last_fetched_at=timestamp(sub.feed.last_fetched_at),
+        created_at=timestamp(sub.created_at),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "emoji>=2.11",
     "fastapi>=0.121.0",
     "fastmcp>=3.2.0",
+    "feedparser>=6.0.11",
     "google-cloud-aiplatform>=1.133.0",
     "graphviz>=0.20.3",
     "httpx>=0.28.1",

--- a/settings.toml
+++ b/settings.toml
@@ -83,3 +83,10 @@ manyacg_hybrid_search = true
 # Set to 0 to disable.
 # agent_periodic_sticker_interval = 5
 # agent_periodic_reaction_interval = 3
+
+# RSS 订阅推送
+# rss_enabled = true
+# 白名单模式: 默认开启, 只有 owner 在面板中放行的 chat 可以订阅
+# rss_whitelist_mode = true
+# 轮询间隔(分钟)
+# rss_interval = 30

--- a/tests/test_rss.py
+++ b/tests/test_rss.py
@@ -1,0 +1,894 @@
+"""RSS subscription tests — storage layer plus the panel endpoints.
+
+The storage properties that matter: a feed is shared across subscribers (so the
+poll job fetches each URL once), the per-chat cap and the whitelist gate hold at
+the database layer, and removing the last subscription deletes the feed row so an
+unwanted feed stops being polled. The API tests pin the whitelist/disabled gates
+and the subscription lifecycle, with `fetch_feed` stubbed so no test touches the
+network.
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy
+
+from kmua import database
+from kmua.config import app_config
+from kmua.database.models import ChatPolicy, RssFeed, RssSubscription
+from kmua.services import rss as rss_service
+from kmua.services.rss import FeedEntry, FetchResult
+from tests.webapp_helpers import api_client, bearer, join_chat, make_chat, make_user
+
+pytestmark = pytest.mark.usefixtures("initialised_db")
+
+OWNER_ID = 9100001
+ADMIN_ID = 9100002
+CHAT_ID = -100_910_001
+
+
+@pytest.fixture(autouse=True)
+async def clean_rss():
+    """Empty the RSS tables between tests."""
+    from kmua.database.db import AsyncSessionFactory
+
+    async with AsyncSessionFactory() as session:
+        async with session.begin():
+            await session.execute(sqlalchemy.delete(RssSubscription))
+            await session.execute(sqlalchemy.delete(RssFeed))
+    yield
+
+
+@pytest.fixture
+def whitelist_mode(monkeypatch):
+    monkeypatch.setattr(app_config, "rss_whitelist_mode", True, raising=False)
+
+
+@pytest.fixture
+def no_whitelist_mode(monkeypatch):
+    monkeypatch.setattr(app_config, "rss_whitelist_mode", False, raising=False)
+
+
+# ------------------------------------------------------------------ storage layer
+
+
+async def test_add_subscription_enforces_per_chat_limit():
+    for i in range(database.MAX_FEEDS_PER_CHAT):
+        sub, reason = await database.add_subscription(
+            -100900001, f"http://feed{i}.test"
+        )
+        assert sub is not None and reason is None
+
+    sub, reason = await database.add_subscription(
+        -100900001, "http://one-too-many.test"
+    )
+    assert sub is None and reason == "limit_reached"
+
+
+async def test_add_subscription_rejects_duplicates():
+    sub, reason = await database.add_subscription(-100900001, "http://feed.test")
+    assert sub is not None and reason is None
+
+    sub, reason = await database.add_subscription(-100900001, "http://feed.test")
+    assert sub is None and reason == "already_subscribed"
+
+
+async def test_remove_subscription_deletes_orphan_feed():
+    sub, _ = await database.add_subscription(-100900001, "http://feed.test")
+    await database.add_subscription(-100900002, "http://feed.test")
+
+    await database.remove_subscription(-100900001, sub.feed_id)
+    assert (
+        await database.get_feed_by_url("http://feed.test") is not None
+    )  # 还有另一个订阅者
+
+    await database.remove_subscription(-100900002, sub.feed_id)
+    assert (
+        await database.get_feed_by_url("http://feed.test") is None
+    )  # 最后一个订阅者走了, feed 也删
+
+
+async def test_remove_an_absent_subscription_is_false():
+    sub, _ = await database.add_subscription(-100900001, "http://feed.test")
+    assert await database.remove_subscription(-100900002, sub.feed_id) is False
+
+
+async def test_pause_and_resume():
+    sub, _ = await database.add_subscription(-100900001, "http://feed.test")
+
+    assert await database.set_subscription_paused(-100900001, sub.feed_id, True) is True
+    assert await database.get_feed_target_chats(sub.feed_id) == []
+    assert await database.get_active_feeds() == []
+
+    assert (
+        await database.set_subscription_paused(-100900001, sub.feed_id, False) is True
+    )
+    assert await database.get_feed_target_chats(sub.feed_id) == [-100900001]
+    assert [f.url for f, _ in await database.get_active_feeds()] == ["http://feed.test"]
+
+
+async def test_pausing_an_absent_subscription_is_false():
+    assert await database.set_subscription_paused(-100900001, 999, True) is False
+
+
+async def test_get_active_feeds_skips_fully_paused_feeds():
+    sub, _ = await database.add_subscription(-100900001, "http://a.test")
+    sub2, _ = await database.add_subscription(-100900001, "http://b.test")
+    await database.set_subscription_paused(-100900001, sub.feed_id, True)
+
+    active = await database.get_active_feeds()
+    assert [f.url for f, _ in active] == ["http://b.test"]
+    assert sub2.feed_id in {f.id for f, _ in active}
+
+
+async def test_active_feeds_default_to_the_global_interval(monkeypatch):
+    monkeypatch.setattr(app_config, "rss_interval", 30, raising=False)
+    await database.add_subscription(-100900001, "http://feed.test")
+
+    (feed, minutes), *_ = await database.get_active_feeds()
+    assert feed.url == "http://feed.test"
+    assert minutes == 30
+
+
+async def test_active_feed_interval_is_the_minimum_across_subscriptions():
+    sub, _ = await database.add_subscription(-100900001, "http://feed.test")
+    await database.add_subscription(-100900002, "http://feed.test")
+
+    await database.set_subscription_interval(-100900001, sub.feed_id, 10)
+    await database.set_subscription_interval(-100900002, sub.feed_id, 5)
+
+    (_, minutes), *_ = await database.get_active_feeds()
+    assert minutes == 5
+
+    # Pausing the fast subscriber lets the slower one set the pace.
+    await database.set_subscription_paused(-100900002, sub.feed_id, True)
+    (_, minutes), *_ = await database.get_active_feeds()
+    assert minutes == 10
+
+
+async def test_set_subscription_interval_and_reset():
+    sub, _ = await database.add_subscription(-100900001, "http://feed.test")
+    assert await database.set_subscription_interval(-100900001, sub.feed_id, 7) is True
+    assert await database.set_subscription_interval(-100900001, 999, 7) is False
+
+    listed = await database.get_chat_subscriptions(-100900001)
+    assert listed[0].interval_minutes == 7
+
+    await database.set_subscription_interval(-100900001, sub.feed_id, None)
+    listed = await database.get_chat_subscriptions(-100900001)
+    assert listed[0].interval_minutes is None
+
+
+async def test_touch_fetch_updates_last_fetched_at():
+    sub, _ = await database.add_subscription(-100900001, "http://feed.test")
+    feed = await database.get_feed_by_id(sub.feed_id)
+    assert feed.last_fetched_at is None
+
+    await database.touch_fetch(sub.feed_id)
+    feed = await database.get_feed_by_id(sub.feed_id)
+    assert feed.last_fetched_at is not None
+    assert feed.last_error is None and feed.seen_entry_ids == []
+
+
+async def test_get_chat_subscriptions_is_newest_first():
+    subs = []
+    for i in range(3):
+        sub, _ = await database.add_subscription(-100900001, f"http://feed{i}.test")
+        subs.append(sub)
+
+    listed = await database.get_chat_subscriptions(-100900001)
+    assert [s.id for s in listed] == [subs[2].id, subs[1].id, subs[0].id]
+
+
+async def test_paged_subscriptions(whitelist_mode):
+    for i in range(5):
+        await database.add_subscription(-100900001, f"http://feed{i}.test")
+
+    page1 = await database.get_chat_subscriptions_paged(-100900001, page=1, size=2)
+    assert page1.total == 5
+    assert len(page1.items) == 2
+    page2 = await database.get_chat_subscriptions_paged(-100900001, page=2, size=2)
+    assert len(page2.items) == 2
+    assert {s.id for s in page1.items}.isdisjoint({s.id for s in page2.items})
+
+
+async def test_record_fetch_success_seeds_seen_ids_and_clears_error():
+    sub, _ = await database.add_subscription(-100900001, "http://feed.test")
+    await database.record_fetch_failure(sub.feed_id, "HTTPStatusError: 404")
+
+    feed = await database.get_feed_by_id(sub.feed_id)
+    assert feed.last_error is not None
+    assert feed.failure_count == 1
+
+    await database.record_fetch_success(
+        sub.feed_id,
+        title="Test Feed",
+        etag='"abc"',
+        last_modified="Wed, 01 Jan 2026 00:00:00 GMT",
+        seen_entry_ids=["a", "b"],
+    )
+
+    feed = await database.get_feed_by_id(sub.feed_id)
+    assert feed.last_error is None
+    assert feed.failure_count == 0
+    assert feed.title == "Test Feed"
+    assert feed.etag == '"abc"'
+    assert feed.seen_entry_ids == ["a", "b"]
+
+
+async def test_record_fetch_success_truncates_the_seen_window():
+    sub, _ = await database.add_subscription(-100900001, "http://feed.test")
+
+    await database.record_fetch_success(
+        sub.feed_id,
+        title=None,
+        etag=None,
+        last_modified=None,
+        seen_entry_ids=[str(i) for i in range(database.MAX_SEEN_IDS + 10)],
+    )
+
+    feed = await database.get_feed_by_id(sub.feed_id)
+    assert len(feed.seen_entry_ids) == database.MAX_SEEN_IDS
+    assert feed.seen_entry_ids[0] == "10"
+
+
+async def test_record_fetch_success_keeps_an_existing_title():
+    sub, _ = await database.add_subscription(-100900001, "http://feed.test")
+    await database.record_fetch_success(
+        sub.feed_id,
+        title="Real Title",
+        etag=None,
+        last_modified=None,
+        seen_entry_ids=[],
+    )
+
+    await database.record_fetch_success(
+        sub.feed_id, title="", etag=None, last_modified=None, seen_entry_ids=[]
+    )
+
+    feed = await database.get_feed_by_id(sub.feed_id)
+    assert feed.title == "Real Title"
+
+
+async def test_delete_chat_subscriptions_drops_all_rows():
+    sub, _ = await database.add_subscription(-100900001, "http://a.test")
+    sub2, _ = await database.add_subscription(-100900001, "http://b.test")
+    await database.add_subscription(-100900002, "http://a.test")
+
+    removed = await database.delete_chat_subscriptions(-100900001)
+    assert removed == 2
+    assert await database.count_chat_subscriptions(-100900001) == 0
+    assert await database.count_chat_subscriptions(-100900002) == 1
+    assert (
+        sub.feed_id != sub2.feed_id
+    )  # sanity: the two subscriptions target distinct feeds
+
+
+async def test_is_rss_allowed_respects_policy_flag(whitelist_mode):
+    assert await database.is_rss_allowed(-100900001) is False
+
+    await database.set_chat_policy(-100900001, ChatPolicy(rss_allowed=True))
+    assert await database.is_rss_allowed(-100900001) is True
+
+
+async def test_is_rss_allowed_ignores_flag_when_mode_is_off(no_whitelist_mode):
+    assert await database.is_rss_allowed(-100900001) is True
+
+
+# ------------------------------------------------------------------ parsing & rendering
+
+
+def test_plain_text_preserves_paragraph_breaks():
+    raw = (
+        "<article><h2>Title</h2><figure><img src='https://cdn.example.com/a.webp'/></figure>"
+        "<p>First para</p><p>Second para<br/>with break</p></article>"
+    )
+    text = rss_service._plain_text(raw, 1000)
+    assert "Title" in text
+    assert "First para\n\nSecond para" in text
+    assert "with break" in text
+    assert "<" not in text and "img" not in text and "cdn.example.com" not in text
+
+
+def test_plain_text_unescapes_entities():
+    assert (
+        rss_service._plain_text("<p>Tom &amp; Jerry &lt;3</p>", 1000)
+        == "Tom & Jerry <3"
+    )
+
+
+def test_plain_text_collapses_blank_line_runs():
+    assert (
+        rss_service._plain_text("<p>a</p><div></div><p>b</p><br/><p>c</p>", 1000)
+        == "a\n\nb\n\nc"
+    )
+
+
+def test_plain_text_truncates():
+    assert len(rss_service._plain_text("<p>abcdefgh</p>", 5)) == 5
+
+
+def test_sanitize_keeps_inline_formatting():
+    out = rss_service._sanitize_html(
+        "<p>Some <strong>bold</strong> and <em>italic</em> and <s>struck</s> text</p>",
+        1000,
+    )
+    assert "<b>bold</b>" in out
+    assert "<i>italic</i>" in out
+    assert "<s>struck</s>" in out
+
+
+def test_sanitize_protects_code_blocks():
+    out = rss_service._sanitize_html(
+        "<p>Before</p><pre><code>def f():\n    return 1 < 2</code></pre><p>After</p>",
+        1000,
+    )
+    # The inner <code> wrapper is stripped so its tag text never shows inside
+    # the block; the content is escaped exactly once.
+    assert "<pre>def f():\n    return 1 &lt; 2</pre>" in out
+    assert "<code>" not in out
+    assert "Before\n\n" in out
+
+
+def test_sanitize_code_block_content_is_escaped_once():
+    out = rss_service._sanitize_html(
+        '<pre><code class="language-sh">a &lt; b &amp;&amp; c > d</code></pre>', 1000
+    )
+    assert out == "<pre>a &lt; b &amp;&amp; c &gt; d</pre>"
+
+
+def test_sanitize_keeps_inline_code():
+    out = rss_service._sanitize_html("<p>use <code>sendMessage</code> here</p>", 1000)
+    assert out == "use <code>sendMessage</code> here"
+
+
+def test_sanitize_br_inside_code_block_is_a_line_break():
+    out = rss_service._sanitize_html("<pre><code>line1<br/>line2</code></pre>", 1000)
+    assert out == "<pre>line1\nline2</pre>"
+
+
+def test_sanitize_strips_html_comments():
+    out = rss_service._sanitize_html("<p>before<!-- more -->after</p>", 1000)
+    assert out == "beforeafter"
+
+
+def test_sanitize_strips_unknown_tags_and_escapes_text():
+    out = rss_service._sanitize_html(
+        '<p>An <a href="https://e.com/x">inline link</a> and <script>evil()</script></p>',
+        1000,
+    )
+    assert "inline link" in out
+    assert "<a" not in out and "script" not in out
+    # literal escaped markup in the source stays literal text
+    out2 = rss_service._sanitize_html("<p>&lt;b&gt;not bold&lt;/b&gt;</p>", 1000)
+    assert out2 == "&lt;b&gt;not bold&lt;/b&gt;"
+
+
+def test_sanitize_balances_tags():
+    out = rss_service._sanitize_html(
+        "<p>unclosed <b>bold without close</p><p>ok</p>", 1000
+    )
+    assert "<b>" not in out and "</b>" not in out
+    assert "bold without close" in out
+    assert out.count("<p>") == out.count("</p>") == 0  # p is not kept at all
+
+
+def test_sanitize_truncation_drops_broken_code_block():
+    body = "<p>" + "x" * 100 + "</p><pre><code>long code block</code></pre>"
+    out = rss_service._sanitize_html(body, 80)
+    assert "<pre>" not in out  # placeholder cut in half -> whole block dropped
+    assert "\x00" not in out
+
+
+def test_truncate_for_delivery_cuts_at_paragraph_boundary():
+    text = "<b>head</b>\n\n" + "p" * 3000 + "\n\n" + "q" * 3000
+    out = rss_service.truncate_for_delivery(text, 3500)
+    assert len(out) <= 3500
+    assert "q" not in out
+    assert out.endswith(" …")
+    assert out.count("<b>") == out.count("</b>")
+
+
+def test_truncate_for_delivery_short_text_is_untouched():
+    text = "<b>short</b>"
+    assert rss_service.truncate_for_delivery(text, 4096) == text
+
+
+# ------------------------------------------------------------------ security guards
+
+
+def test_redact_url_strips_query_userinfo_and_fragment():
+    assert (
+        rss_service.redact_url("https://user:pass@example.com/feed.xml?token=abc#frag")
+        == "https://example.com/feed.xml"
+    )
+    assert rss_service.redact_url("https://example.com:8443/feed?k=v") == (
+        "https://example.com:8443/feed"
+    )
+    assert rss_service.redact_url("not a url") == "not a url"
+
+
+def test_is_blocked_ip_covers_metadata_and_private_ranges():
+    import ipaddress
+
+    for ip in [
+        "127.0.0.1",
+        "10.1.2.3",
+        "172.16.0.1",
+        "192.168.1.1",
+        "169.254.169.254",  # cloud metadata
+        "100.64.0.1",  # CGNAT
+        "0.0.0.0",
+        "192.0.2.1",  # documentation
+        "::1",
+        "fc00::1",
+        "fe80::1",
+        "::ffff:127.0.0.1",  # IPv4-mapped loopback
+    ]:
+        assert rss_service._is_blocked_ip(ipaddress.ip_address(ip)), ip
+
+    for ip in ["8.8.8.8", "1.1.1.1", "2606:4700::1111"]:
+        assert not rss_service._is_blocked_ip(ipaddress.ip_address(ip)), ip
+
+
+def test_sanitize_drops_ctrl_entity_forgery():
+    # &#1; decodes to \x01, the sanitizer's own tag-token sentinel; the entities
+    # are dropped, so the source cannot forge a token into a real tag.
+    out = rss_service._sanitize_html("<p>a&#1;ob&#1;b</p>", 1000)
+    assert "<b>" not in out
+    assert "\x01" not in out
+    assert out == "aobb"
+
+
+def test_sanitize_forged_placeholder_index_is_dropped():
+    out = rss_service._sanitize_html("<p>a\x00999\x00b</p>", 1000)
+    assert "\x00" not in out
+    assert out == "ab"
+
+
+def test_fetch_drops_non_http_entry_links():
+    # fetch_feed builds links through urljoin; a javascript: entry link must not
+    # reach the rendered href.
+    import feedparser
+
+    doc = feedparser.parse(
+        b"""<?xml version="1.0"?><rss version="2.0"><channel>
+        <title>t</title><link>https://e.com/</link>
+        <item><title>x</title><link>javascript:alert(1)</link></item>
+        </channel></rss>"""
+    )
+    raw = doc.entries[0]
+    # Directly exercise the same link construction used in fetch_feed.
+    link = __import__("urllib.parse", fromlist=["urljoin"]).urljoin(
+        "https://e.com/", raw.get("link", "")
+    )
+    assert not link.startswith(("http://", "https://"))
+
+
+def test_entry_html_prefers_content():
+    raw = {"content": [{"value": "<p>full</p>"}], "summary": "short"}
+    assert rss_service._entry_html(raw) == "<p>full</p>"
+    assert rss_service._entry_html({"summary": "short"}) == "short"
+    assert rss_service._entry_html({"description": "desc"}) == "desc"
+
+
+def test_extract_media_from_imgs_and_enclosures():
+    raw = {
+        "enclosures": [
+            {"type": "image/jpeg", "url": "/media/cover.jpg"},
+            {"type": "audio/mpeg", "url": "/a.mp3"},
+        ]
+    }
+    media = rss_service._extract_media(
+        "<p><img src='https://cdn.example.com/1.webp'/><img src='/rel/2.png'/></p>",
+        raw,
+        "https://example.com/feed.xml",
+    )
+    assert media == [
+        "https://cdn.example.com/1.webp",
+        "https://example.com/rel/2.png",
+        "https://example.com/media/cover.jpg",
+    ]
+
+
+def test_extract_media_caps_and_dedupes():
+    raw = {"enclosures": [{"type": "image/jpeg", "url": "https://e.com/x.jpg"}]}
+    html_src = "".join(f"<img src='https://cdn.e.com/{i}.jpg'/>" for i in range(5))
+    media = rss_service._extract_media(html_src, raw, "https://e.com/feed")
+    assert len(media) == 3
+    assert len(set(media)) == 3
+
+
+def test_render_entry_keeps_summary_newlines():
+    entry = FeedEntry(
+        entry_id="1", title="T", link="https://e.com/1", summary="line1\n\nline2"
+    )
+    out = rss_service.render_entry("F", entry, "zh-CN")
+    assert "line1\n\nline2" in out
+    assert '<a href="https://e.com/1">T</a>' in out
+
+
+# --------------------------------------------------------------------------- API
+
+
+@pytest.fixture
+async def chat_admin(monkeypatch):
+    admin = await make_user(ADMIN_ID, full_name="RSS Admin")
+    chat = await make_chat(CHAT_ID, title="RSS Chat")
+    await join_chat(admin, chat, bot_admin=True)
+    return admin, chat
+
+
+def _allow_rss():
+    """Whitelist the chat directly at the storage layer."""
+    return database.set_chat_policy(CHAT_ID, ChatPolicy(rss_allowed=True))
+
+
+async def test_list_rss_requires_whitelist(monkeypatch, whitelist_mode, chat_admin):
+    async with api_client() as client:
+        response = await client.get(
+            f"/api/chats/{CHAT_ID}/rss", headers=bearer(ADMIN_ID)
+        )
+
+    assert response.status_code == 403
+    assert response.json()["code"] == "FORBIDDEN"
+
+
+async def test_list_rss_works_when_whitelisted(monkeypatch, whitelist_mode, chat_admin):
+    await _allow_rss()
+    async with api_client() as client:
+        response = await client.get(
+            f"/api/chats/{CHAT_ID}/rss", headers=bearer(ADMIN_ID)
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["items"] == []
+    assert body["total"] == 0
+
+
+async def test_list_rss_requires_chat_admin(monkeypatch, whitelist_mode):
+    await _allow_rss()
+    plain = await make_user(OWNER_ID, full_name="Plain User")
+    await make_chat(CHAT_ID, title="RSS Chat")
+    async with api_client() as client:
+        response = await client.get(
+            f"/api/chats/{CHAT_ID}/rss", headers=bearer(plain.id)
+        )
+
+    assert response.status_code == 403
+
+
+async def test_rss_disabled_everywhere(monkeypatch, chat_admin):
+    monkeypatch.setattr(app_config, "rss_enabled", False, raising=False)
+    await _allow_rss()
+    async with api_client() as client:
+        response = await client.get(
+            f"/api/chats/{CHAT_ID}/rss", headers=bearer(ADMIN_ID)
+        )
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "FEATURE_DISABLED"
+
+
+async def test_add_rejects_a_non_http_url(monkeypatch, whitelist_mode, chat_admin):
+    await _allow_rss()
+    async with api_client() as client:
+        response = await client.post(
+            f"/api/chats/{CHAT_ID}/rss",
+            headers=bearer(ADMIN_ID),
+            json={"url": "ftp://example.com/feed.xml"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "VALIDATION_FAILED"
+
+
+async def test_add_reports_an_unfetchable_feed(monkeypatch, whitelist_mode, chat_admin):
+    await _allow_rss()
+
+    async def broken_fetch(url, *, etag=None, last_modified=None):
+        raise ValueError("feed too large")
+
+    monkeypatch.setattr(rss_service, "fetch_feed", broken_fetch)
+    async with api_client() as client:
+        response = await client.post(
+            f"/api/chats/{CHAT_ID}/rss",
+            headers=bearer(ADMIN_ID),
+            json={"url": "http://example.com/feed.xml"},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["code"] == "VALIDATION_FAILED"
+    assert "ValueError" in response.json()["message"]
+    assert await database.count_chat_subscriptions(CHAT_ID) == 0
+
+
+async def test_add_subscribes_and_seeds_seen_ids(
+    monkeypatch, whitelist_mode, chat_admin
+):
+    await _allow_rss()
+
+    async def fake_fetch(url, *, etag=None, last_modified=None):
+        return FetchResult(
+            not_modified=False,
+            feed_title="HN",
+            entries=[FeedEntry(entry_id="1", title="Post", link="", summary="")],
+            etag=None,
+            last_modified=None,
+        )
+
+    monkeypatch.setattr(rss_service, "fetch_feed", fake_fetch)
+    async with api_client() as client:
+        response = await client.post(
+            f"/api/chats/{CHAT_ID}/rss",
+            headers=bearer(ADMIN_ID),
+            json={"url": "http://example.com/feed.xml"},
+        )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["url"] == "http://example.com/feed.xml"
+    assert body["title"] == "HN"
+    assert body["paused"] is False
+
+    feed = await database.get_feed_by_url("http://example.com/feed.xml")
+    assert feed.seen_entry_ids == ["1"]
+
+
+async def test_add_a_duplicate_is_a_conflict(monkeypatch, whitelist_mode, chat_admin):
+    await _allow_rss()
+
+    async def fake_fetch(url, *, etag=None, last_modified=None):
+        return FetchResult(
+            not_modified=False,
+            feed_title=None,
+            entries=[],
+            etag=None,
+            last_modified=None,
+        )
+
+    monkeypatch.setattr(rss_service, "fetch_feed", fake_fetch)
+    async with api_client() as client:
+        first = await client.post(
+            f"/api/chats/{CHAT_ID}/rss",
+            headers=bearer(ADMIN_ID),
+            json={"url": "http://example.com/feed.xml"},
+        )
+        assert first.status_code == 201
+
+        second = await client.post(
+            f"/api/chats/{CHAT_ID}/rss",
+            headers=bearer(ADMIN_ID),
+            json={"url": "http://example.com/feed.xml"},
+        )
+
+    assert second.status_code == 409
+    assert second.json()["code"] == "CONFLICT"
+
+
+async def test_patch_pauses_and_returns_the_list(
+    monkeypatch, whitelist_mode, chat_admin
+):
+    await _allow_rss()
+
+    async def fake_fetch(url, *, etag=None, last_modified=None):
+        return FetchResult(
+            not_modified=False,
+            feed_title=None,
+            entries=[],
+            etag=None,
+            last_modified=None,
+        )
+
+    monkeypatch.setattr(rss_service, "fetch_feed", fake_fetch)
+    async with api_client() as client:
+        added = await client.post(
+            f"/api/chats/{CHAT_ID}/rss",
+            headers=bearer(ADMIN_ID),
+            json={"url": "http://example.com/feed.xml"},
+        )
+        feed_id = added.json()["feed_id"]
+
+        patched = await client.patch(
+            f"/api/chats/{CHAT_ID}/rss/{feed_id}",
+            headers=bearer(ADMIN_ID),
+            json={"paused": True},
+        )
+
+    assert patched.status_code == 200
+    items = patched.json()
+    assert len(items) == 1
+    assert items[0]["paused"] is True
+    assert items[0]["interval_minutes"] is None
+
+    subs = await database.get_chat_subscriptions(CHAT_ID)
+    assert subs[0].paused is True
+
+
+async def test_patch_sets_and_resets_the_interval(
+    monkeypatch, whitelist_mode, chat_admin
+):
+    await _allow_rss()
+
+    async def fake_fetch(url, *, etag=None, last_modified=None):
+        return FetchResult(
+            not_modified=False,
+            feed_title=None,
+            entries=[],
+            etag=None,
+            last_modified=None,
+        )
+
+    monkeypatch.setattr(rss_service, "fetch_feed", fake_fetch)
+    async with api_client() as client:
+        added = await client.post(
+            f"/api/chats/{CHAT_ID}/rss",
+            headers=bearer(ADMIN_ID),
+            json={"url": "http://example.com/feed.xml"},
+        )
+        feed_id = added.json()["feed_id"]
+
+        set_interval = await client.patch(
+            f"/api/chats/{CHAT_ID}/rss/{feed_id}",
+            headers=bearer(ADMIN_ID),
+            json={"interval_minutes": 5},
+        )
+        assert set_interval.status_code == 200
+        assert set_interval.json()[0]["interval_minutes"] == 5
+        # paused is untouched by an interval-only patch
+        assert set_interval.json()[0]["paused"] is False
+
+        reset = await client.patch(
+            f"/api/chats/{CHAT_ID}/rss/{feed_id}",
+            headers=bearer(ADMIN_ID),
+            json={"interval_minutes": None},
+        )
+        assert reset.status_code == 200
+        assert reset.json()[0]["interval_minutes"] is None
+
+        out_of_range = await client.patch(
+            f"/api/chats/{CHAT_ID}/rss/{feed_id}",
+            headers=bearer(ADMIN_ID),
+            json={"interval_minutes": 0},
+        )
+        assert out_of_range.status_code == 422
+
+        subs = await database.get_chat_subscriptions(CHAT_ID)
+        assert subs[0].interval_minutes is None
+
+
+async def test_patch_an_absent_subscription_is_a_404(
+    monkeypatch, whitelist_mode, chat_admin
+):
+    await _allow_rss()
+    async with api_client() as client:
+        response = await client.patch(
+            f"/api/chats/{CHAT_ID}/rss/999",
+            headers=bearer(ADMIN_ID),
+            json={"paused": True},
+        )
+
+    assert response.status_code == 404
+    assert response.json()["code"] == "NOT_FOUND"
+
+
+async def test_delete_removes_the_subscription(monkeypatch, whitelist_mode, chat_admin):
+    await _allow_rss()
+
+    async def fake_fetch(url, *, etag=None, last_modified=None):
+        return FetchResult(
+            not_modified=False,
+            feed_title=None,
+            entries=[],
+            etag=None,
+            last_modified=None,
+        )
+
+    monkeypatch.setattr(rss_service, "fetch_feed", fake_fetch)
+    async with api_client() as client:
+        added = await client.post(
+            f"/api/chats/{CHAT_ID}/rss",
+            headers=bearer(ADMIN_ID),
+            json={"url": "http://example.com/feed.xml"},
+        )
+        feed_id = added.json()["feed_id"]
+
+        deleted = await client.delete(
+            f"/api/chats/{CHAT_ID}/rss/{feed_id}", headers=bearer(ADMIN_ID)
+        )
+        gone = await client.delete(
+            f"/api/chats/{CHAT_ID}/rss/{feed_id}", headers=bearer(ADMIN_ID)
+        )
+
+    assert deleted.status_code == 204
+    assert gone.status_code == 404
+    assert await database.count_chat_subscriptions(CHAT_ID) == 0
+    assert await database.get_feed_by_url("http://example.com/feed.xml") is None
+
+
+# ----------------------------------------------------------------- personal (/api/me/rss)
+
+ME_ID = 9100004
+
+
+async def test_me_rss_requires_whitelist(monkeypatch, whitelist_mode):
+    await make_user(ME_ID, full_name="Me User")
+    async with api_client() as client:
+        response = await client.get("/api/me/rss", headers=bearer(ME_ID))
+
+    assert response.status_code == 403
+    assert response.json()["code"] == "FORBIDDEN"
+
+
+async def test_me_rss_lifecycle(monkeypatch, whitelist_mode):
+    await make_user(ME_ID, full_name="Me User")
+    await database.set_chat_policy(ME_ID, ChatPolicy(rss_allowed=True))
+
+    async def fake_fetch(url, *, etag=None, last_modified=None):
+        return FetchResult(
+            not_modified=False,
+            feed_title="Me Feed",
+            entries=[FeedEntry(entry_id="1", title="P", link="", summary="")],
+            etag=None,
+            last_modified=None,
+        )
+
+    monkeypatch.setattr(rss_service, "fetch_feed", fake_fetch)
+    async with api_client() as client:
+        added = await client.post(
+            "/api/me/rss", headers=bearer(ME_ID), json={"url": "http://me.test/feed"}
+        )
+        assert added.status_code == 201
+        assert added.json()["title"] == "Me Feed"
+
+        listed = await client.get("/api/me/rss", headers=bearer(ME_ID))
+        assert listed.status_code == 200
+        assert listed.json()["total"] == 1
+
+        feed_id = added.json()["feed_id"]
+        patched = await client.patch(
+            f"/api/me/rss/{feed_id}", headers=bearer(ME_ID), json={"paused": True}
+        )
+        assert patched.status_code == 200
+        assert patched.json()[0]["paused"] is True
+
+        deleted = await client.delete(f"/api/me/rss/{feed_id}", headers=bearer(ME_ID))
+        assert deleted.status_code == 204
+
+    assert await database.count_chat_subscriptions(ME_ID) == 0
+    assert await database.get_feed_by_url("http://me.test/feed") is None
+
+
+async def test_me_rss_is_scoped_to_the_caller(monkeypatch, whitelist_mode):
+    other = await make_user(ME_ID + 1, full_name="Other User")
+    await make_user(ME_ID, full_name="Me User")
+    await database.set_chat_policy(ME_ID, ChatPolicy(rss_allowed=True))
+    await database.set_chat_policy(other.id, ChatPolicy(rss_allowed=True))
+
+    async def fake_fetch(url, *, etag=None, last_modified=None):
+        return FetchResult(
+            not_modified=False,
+            feed_title=None,
+            entries=[],
+            etag=None,
+            last_modified=None,
+        )
+
+    monkeypatch.setattr(rss_service, "fetch_feed", fake_fetch)
+    async with api_client() as client:
+        await client.post(
+            "/api/me/rss", headers=bearer(ME_ID), json={"url": "http://me.test/feed"}
+        )
+
+        # The other user sees nothing of the first user's subscription.
+        listed = await client.get("/api/me/rss", headers=bearer(other.id))
+        assert listed.status_code == 200
+        assert listed.json()["total"] == 0
+
+        # And cannot pause or delete it: the feed id is scoped by session user.
+        feed_id = (await database.get_feed_by_url("http://me.test/feed")).id
+        gone = await client.delete(f"/api/me/rss/{feed_id}", headers=bearer(other.id))
+        assert gone.status_code == 404
+
+    assert await database.count_chat_subscriptions(ME_ID) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -984,6 +984,27 @@ wheels = [
 ]
 
 [[package]]
+name = "feedparser"
+version = "6.0.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "feedparser-sgmllib" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/8a/a53da4a77352045d277978a2df322d5379369f9deb1707178899ff7e1121/feedparser-6.0.14.tar.gz", hash = "sha256:088679b0c4b543ee211a820dd544698c76a402122eae7473c04a43425f283d06", size = 286108, upload-time = "2026-07-30T14:07:40.491Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/61/f04912e63702e73fb2a378f9c0a1ad9eb17a334a11a6b3fe1daa593903c2/feedparser-6.0.14-py3-none-any.whl", hash = "sha256:e35e3f760151b0c3b22cac9684155cae186a233e16c49bcbc6c49e91e3131137", size = 80668, upload-time = "2026-07-30T14:07:39.175Z" },
+]
+
+[[package]]
+name = "feedparser-sgmllib"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/bf/ae3f20eceaa25fe720ec8f14662d35d39e73839fbbdad3c13bdee5397237/feedparser_sgmllib-2.0.1.tar.gz", hash = "sha256:32d46a92fe429d033c6793a45d4af28a150ff3e74f5bfdb598e26811ce4c2664", size = 22962, upload-time = "2026-07-30T19:18:10.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ce/35ac725a2b0e6b3f4e03bb68167501cdecf3935132927c61342747f734a9/feedparser_sgmllib-2.0.1-py3-none-any.whl", hash = "sha256:113d6e0d7e1196200a13013044999aef75772d515f25a3e77c5e2047eb82c212", size = 10008, upload-time = "2026-07-30T19:18:09.237Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.32.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1904,6 +1925,7 @@ dependencies = [
     { name = "emoji" },
     { name = "fastapi" },
     { name = "fastmcp" },
+    { name = "feedparser" },
     { name = "google-cloud-aiplatform" },
     { name = "graphviz" },
     { name = "httpx" },
@@ -1956,6 +1978,7 @@ requires-dist = [
     { name = "emoji", specifier = ">=2.11" },
     { name = "fastapi", specifier = ">=0.121.0" },
     { name = "fastmcp", specifier = ">=3.2.0" },
+    { name = "feedparser", specifier = ">=6.0.11" },
     { name = "google-cloud-aiplatform", specifier = ">=1.133.0" },
     { name = "graphviz", specifier = ">=0.20.3" },
     { name = "httpx", specifier = ">=0.28.1" },

--- a/webapp/src/api/endpoints/chats.ts
+++ b/webapp/src/api/endpoints/chats.ts
@@ -6,6 +6,7 @@ import type {
   ChatDetail,
   Page,
   Quote,
+  RssSubscription,
   SyncMembersResult,
 } from "../types";
 
@@ -52,4 +53,29 @@ export function fetchChatQuotes(
 
 export function deleteChatQuote(chatId: number, link: string) {
   return api.delete<void>(`/api/chats/${chatId}/quotes/${encodeURIComponent(link)}`);
+}
+
+export function fetchChatRss(chatId: number, page: number, size: number, signal?: AbortSignal) {
+  return api.get<Page<RssSubscription>>(`/api/chats/${chatId}/rss`, {
+    query: { page, size },
+    ...(signal ? { signal } : {}),
+  });
+}
+
+export function addChatRss(chatId: number, url: string) {
+  return api.post<RssSubscription>(`/api/chats/${chatId}/rss`, { url });
+}
+
+export function setChatRssPaused(chatId: number, feedId: number, paused: boolean) {
+  return api.patch<RssSubscription[]>(`/api/chats/${chatId}/rss/${feedId}`, { paused });
+}
+
+export function setChatRssInterval(chatId: number, feedId: number, minutes: number | null) {
+  return api.patch<RssSubscription[]>(`/api/chats/${chatId}/rss/${feedId}`, {
+    interval_minutes: minutes,
+  });
+}
+
+export function deleteChatRss(chatId: number, feedId: number) {
+  return api.delete<void>(`/api/chats/${chatId}/rss/${feedId}`);
 }

--- a/webapp/src/api/endpoints/me.ts
+++ b/webapp/src/api/endpoints/me.ts
@@ -8,6 +8,7 @@ import type {
   MeConfigPatch,
   Page,
   Quote,
+  RssSubscription,
   Waifu,
 } from "../types";
 
@@ -63,4 +64,27 @@ export function sendGift(giftDbId: number) {
 
 export function refreshMyAvatar() {
   return api.post<{ refreshed: boolean }>("/api/me/avatar/refresh");
+}
+
+export function fetchMyRss(page: number, size: number, signal?: AbortSignal) {
+  return api.get<Page<RssSubscription>>("/api/me/rss", {
+    query: { page, size },
+    ...(signal ? { signal } : {}),
+  });
+}
+
+export function addMyRss(url: string) {
+  return api.post<RssSubscription>("/api/me/rss", { url });
+}
+
+export function setMyRssPaused(feedId: number, paused: boolean) {
+  return api.patch<RssSubscription[]>(`/api/me/rss/${feedId}`, { paused });
+}
+
+export function setMyRssInterval(feedId: number, minutes: number | null) {
+  return api.patch<RssSubscription[]>(`/api/me/rss/${feedId}`, { interval_minutes: minutes });
+}
+
+export function deleteMyRss(feedId: number) {
+  return api.delete<void>(`/api/me/rss/${feedId}`);
 }

--- a/webapp/src/api/types.ts
+++ b/webapp/src/api/types.ts
@@ -283,6 +283,7 @@ export interface Job {
  */
 export interface ChatPolicyFlags {
   agent_allowed: boolean;
+  rss_allowed: boolean;
 }
 
 export interface ChatPolicy {
@@ -298,13 +299,29 @@ export interface ChatPolicy {
 export interface ChatPolicyList {
   /** Whether whitelist mode is on. With it off `agent_allowed` is inert. */
   agent_whitelist_mode: boolean;
+  /** Whether whitelist mode is on. With it off `rss_allowed` is inert. */
+  rss_whitelist_mode: boolean;
   items: ChatPolicy[];
 }
 
 /** A policy write. Absent flags keep their current value. */
 export interface ChatPolicyPatch {
   agent_allowed?: boolean | null;
+  rss_allowed?: boolean | null;
   note?: string | null;
+}
+
+export interface RssSubscription {
+  id: number;
+  feed_id: number;
+  url: string;
+  title: string | null;
+  paused: boolean;
+  /** Minutes; null = follow the global poll interval. */
+  interval_minutes: number | null;
+  last_error: string | null;
+  last_fetched_at: string;
+  created_at: string;
 }
 
 export interface Page<T> {

--- a/webapp/src/components/TextField.vue
+++ b/webapp/src/components/TextField.vue
@@ -16,7 +16,7 @@ withDefaults(
     hint?: string;
     placeholder?: string;
     maxlength?: number;
-    inputmode?: "text" | "numeric" | "decimal" | "search";
+    inputmode?: "text" | "numeric" | "decimal" | "search" | "url";
     changed?: boolean;
     disabled?: boolean;
   }>(),

--- a/webapp/src/components/ToggleSwitch.vue
+++ b/webapp/src/components/ToggleSwitch.vue
@@ -18,14 +18,16 @@ const props = withDefaults(
     disabled?: boolean;
     /** Accessible name, when the visible label lives outside this component. */
     ariaLabel?: string;
+    /** In-flight server write: the knob becomes a spinner and taps are ignored. */
+    busy?: boolean;
   }>(),
-  { disabled: false, ariaLabel: undefined },
+  { disabled: false, ariaLabel: undefined, busy: false },
 );
 
 const emit = defineEmits<{ "update:modelValue": [boolean] }>();
 
 function toggle(): void {
-  if (props.disabled) return;
+  if (props.disabled || props.busy) return;
   haptics.tap();
   emit("update:modelValue", !props.modelValue);
 }
@@ -48,6 +50,11 @@ function toggle(): void {
     <span
       class="absolute top-[3px] left-[3px] block h-6 w-6 rounded-full bg-white transition-transform duration-150 ease-out"
       :class="modelValue ? 'translate-x-5' : 'translate-x-0'"
-    />
+    >
+      <span
+        v-if="busy"
+        class="block h-full w-full rounded-full animate-spin border-2 border-hint border-t-accent"
+      />
+    </span>
   </button>
 </template>

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -62,7 +62,9 @@
     "avatarRefreshed": "Avatar refreshed",
     "avatarUnchanged": "Avatar unchanged",
     "waifuInChats": "Waifu per group",
-    "noWaifu": "Not drawn yet"
+    "noWaifu": "Not drawn yet",
+    "rss": "RSS Subscriptions",
+    "rssHint": "Manage your private-chat RSS subscriptions"
   },
   "quotes": {
     "title": "Quotes",
@@ -115,7 +117,24 @@
     "syncMembersHint": "Drop records of members who left",
     "syncMembersDone": "Removed {count} stale records",
     "quoteProbability": "Random quote chance",
-    "lang": "Group language"
+    "lang": "Group language",
+    "rss": "RSS Subscriptions",
+    "rssHint": "Subscribe to RSS/Atom feeds; new entries are pushed to the group",
+    "rssAdd": "Add subscription",
+    "rssUrl": "Feed URL",
+    "rssUrlPlaceholder": "https://example.com/feed.xml",
+    "rssEmpty": "No feeds subscribed yet",
+    "rssAdded": "Subscription added",
+    "rssRemove": "Unsubscribe",
+    "rssRemoveConfirm": "Unsubscribe from \"{name}\"?",
+    "rssRemoved": "Unsubscribed",
+    "rssPaused": "Paused",
+    "rssActive": "Active",
+    "rssLastFetched": "Last fetched",
+    "rssNeverFetched": "Never fetched",
+    "rssError": "Fetch error",
+    "rssEvery": "every {minutes} min",
+    "rssGlobalInterval": "global interval"
   },
   "chatConfig": {
     "waifu_enabled": "Daily waifu",
@@ -259,6 +278,10 @@
     "agentModeOn": "On: Agent is active only in chats enabled below",
     "agentModeOff": "Off: Agent is active everywhere, the toggles below have no effect",
     "agentAllowed": "Allow Agent",
+    "rssMode": "RSS whitelist mode",
+    "rssModeOn": "On: only chats enabled below may subscribe to RSS",
+    "rssModeOff": "Off: every chat may subscribe to RSS, the toggles below have no effect",
+    "rssAllowed": "Allow RSS subscriptions",
     "chats": "Configured chats",
     "chatsHint": "The toggle controls whether the Agent may act in that chat",
     "emptyHint": "No chats configured yet",

--- a/webapp/src/i18n/zh-CN.json
+++ b/webapp/src/i18n/zh-CN.json
@@ -62,7 +62,9 @@
     "avatarRefreshed": "头像已刷新",
     "avatarUnchanged": "头像没有变化",
     "waifuInChats": "各群的老婆",
-    "noWaifu": "还没抽到"
+    "noWaifu": "还没抽到",
+    "rss": "RSS 订阅",
+    "rssHint": "管理私聊中的 RSS 订阅"
   },
   "quotes": {
     "title": "语录",
@@ -115,7 +117,24 @@
     "syncMembersHint": "移除已经退群的成员记录",
     "syncMembersDone": "清理了 {count} 个成员记录",
     "quoteProbability": "随机引用概率",
-    "lang": "群组语言"
+    "lang": "群组语言",
+    "rss": "RSS 订阅",
+    "rssHint": "订阅 RSS/Atom feed, 新条目自动推送到群里",
+    "rssAdd": "添加订阅",
+    "rssUrl": "Feed URL",
+    "rssUrlPlaceholder": "https://example.com/feed.xml",
+    "rssEmpty": "还没有订阅任何 feed",
+    "rssAdded": "已添加订阅",
+    "rssRemove": "取消订阅",
+    "rssRemoveConfirm": "确定取消订阅「{name}」吗?",
+    "rssRemoved": "已取消订阅",
+    "rssPaused": "已暂停",
+    "rssActive": "推送中",
+    "rssLastFetched": "上次抓取",
+    "rssNeverFetched": "尚未抓取",
+    "rssError": "抓取出错",
+    "rssEvery": "每 {minutes} 分钟",
+    "rssGlobalInterval": "全局间隔"
   },
   "chatConfig": {
     "waifu_enabled": "抽老婆",
@@ -259,6 +278,10 @@
     "agentModeOn": "已开启: Agent 仅在下方启用的群组生效",
     "agentModeOff": "已关闭: Agent 在所有群组生效, 下方开关不起作用",
     "agentAllowed": "允许 Agent",
+    "rssMode": "RSS 白名单模式",
+    "rssModeOn": "已开启: 仅下方启用的群组可以订阅 RSS",
+    "rssModeOff": "已关闭: 所有群组都可以订阅 RSS, 下方开关不起作用",
+    "rssAllowed": "允许 RSS 订阅",
     "chats": "已配置的群组",
     "chatsHint": "开关控制该群是否允许 Agent",
     "emptyHint": "还没有配置任何群组",

--- a/webapp/src/router/index.ts
+++ b/webapp/src/router/index.ts
@@ -38,6 +38,11 @@ const routes: RouteRecordRaw[] = [
     component: () => import("@/views/me/GiftsView.vue"),
   },
   {
+    path: "/me/rss",
+    name: "me-rss",
+    component: () => import("@/views/me/MyRssView.vue"),
+  },
+  {
     path: "/chats",
     name: "chats",
     component: () => import("@/views/chats/ChatListView.vue"),
@@ -64,6 +69,12 @@ const routes: RouteRecordRaw[] = [
     path: "/chats/:chatId/quotes",
     name: "chat-quotes",
     component: () => import("@/views/chats/ChatQuotesView.vue"),
+    props: (route) => ({ chatId: Number(route.params.chatId) }),
+  },
+  {
+    path: "/chats/:chatId/rss",
+    name: "chat-rss",
+    component: () => import("@/views/chats/ChatRssView.vue"),
     props: (route) => ({ chatId: Number(route.params.chatId) }),
   },
   {

--- a/webapp/src/views/admin/ChatPolicyView.vue
+++ b/webapp/src/views/admin/ChatPolicyView.vue
@@ -41,14 +41,17 @@ const { notify, notifyError } = useNotice();
 
 const newChatId = ref("");
 const newNote = ref("");
-/** Which action is in flight: `add`, `toggle:<id>` or `remove:<id>`. */
-const pending = ref<"add" | `toggle:${number}` | `remove:${number}` | null>(null);
+/** Which action is in flight: `add`, `toggle:<id>`, `toggle-rss:<id>` or `remove:<id>`. */
+const pending = ref<
+  "add" | `toggle:${number}` | `toggle-rss:${number}` | `remove:${number}` | null
+>(null);
 const busy = computed(() => pending.value !== null);
 
 const policies = useAsyncData((signal) => fetchChatPolicies(signal));
 
 const items = computed(() => policies.data.value?.items ?? []);
 const whitelistMode = computed(() => policies.data.value?.agent_whitelist_mode ?? false);
+const rssWhitelistMode = computed(() => policies.data.value?.rss_whitelist_mode ?? false);
 
 /**
  * A group id is negative and Telegram supergroup ids are long, so the field is
@@ -120,6 +123,22 @@ async function toggleAgent(item: ChatPolicy, value: boolean): Promise<void> {
   }
 }
 
+async function toggleRss(item: ChatPolicy, value: boolean): Promise<void> {
+  if (busy.value) return;
+
+  pending.value = `toggle-rss:${item.chat_id}`;
+  try {
+    policies.data.value = await setChatPolicy(item.chat_id, { rss_allowed: value });
+    notify(t("app.saved"));
+    haptics.success();
+  } catch (error) {
+    notifyError(isApiError(error) ? tError(error.code) : t("app.loadFailed"));
+    haptics.error();
+  } finally {
+    pending.value = null;
+  }
+}
+
 async function remove(item: ChatPolicy): Promise<void> {
   const ok = await confirm({
     title: t("chatPolicy.remove"),
@@ -157,6 +176,11 @@ async function remove(item: ChatPolicy): Promise<void> {
         :value="whitelistMode ? t('app.yes') : t('app.no')"
         :hint="whitelistMode ? t('chatPolicy.agentModeOn') : t('chatPolicy.agentModeOff')"
       />
+      <SettingsRow
+        :label="t('chatPolicy.rssMode')"
+        :value="rssWhitelistMode ? t('app.yes') : t('app.no')"
+        :hint="rssWhitelistMode ? t('chatPolicy.rssModeOn') : t('chatPolicy.rssModeOff')"
+      />
     </SettingsSection>
 
     <SettingsSection
@@ -169,14 +193,21 @@ async function remove(item: ChatPolicy): Promise<void> {
         :label="label(item)"
         :hint="hint(item)"
         :disabled="busy"
-        :busy="pending === `toggle:${item.chat_id}`"
       >
         <template #control>
           <ToggleSwitch
             :model-value="item.policy.agent_allowed"
             :disabled="!session.isOwner || busy"
+            :busy="pending === `toggle:${item.chat_id}`"
             :aria-label="t('chatPolicy.agentAllowed')"
             @update:model-value="toggleAgent(item, $event)"
+          />
+          <ToggleSwitch
+            :model-value="item.policy.rss_allowed"
+            :disabled="!session.isOwner || busy"
+            :aria-label="t('chatPolicy.rssAllowed')"
+            :busy="pending === `toggle-rss:${item.chat_id}`"
+            @update:model-value="toggleRss(item, $event)"
           />
         </template>
       </SettingsRow>

--- a/webapp/src/views/chats/ChatConfigView.vue
+++ b/webapp/src/views/chats/ChatConfigView.vue
@@ -200,6 +200,12 @@ function go(name: string): void {
         navigable
         @click="go('chat-quotes')"
       />
+      <SettingsRow
+        :label="t('chats.rss')"
+        :hint="t('chats.rssHint')"
+        navigable
+        @click="go('chat-rss')"
+      />
       <SettingsRow :label="t('chats.members')" :value="chat.data.value?.member_count ?? 0" />
     </SettingsSection>
   </StateBlock>

--- a/webapp/src/views/chats/ChatRssView.vue
+++ b/webapp/src/views/chats/ChatRssView.vue
@@ -1,0 +1,211 @@
+<script setup lang="ts">
+/**
+ * A group's RSS/Atom subscriptions: add a feed by URL, toggle push per feed, and
+ * remove. Mirrors the `/rss` command; the server enforces the same whitelist gate
+ * (`rss_allowed` policy flag) on every request this page makes.
+ */
+import { computed, ref, watch } from "vue";
+
+import {
+  addChatRss,
+  deleteChatRss,
+  fetchChat,
+  fetchChatRss,
+  setChatRssPaused,
+} from "@/api/endpoints/chats";
+import { isApiError } from "@/api/errors";
+import type { RssSubscription } from "@/api/types";
+import PageHeader from "@/components/PageHeader.vue";
+import PagerBar from "@/components/PagerBar.vue";
+import SettingsRow from "@/components/SettingsRow.vue";
+import SettingsSection from "@/components/SettingsSection.vue";
+import StateBlock from "@/components/StateBlock.vue";
+import TextField from "@/components/TextField.vue";
+import ToggleSwitch from "@/components/ToggleSwitch.vue";
+import { useAsyncData } from "@/composables/useAsyncData";
+import { useNotice } from "@/composables/useNotice";
+import { t, tError } from "@/i18n";
+import { confirm, haptics } from "@/telegram";
+import { formatDate } from "@/utils/format";
+
+const props = defineProps<{ chatId: number }>();
+
+const PAGE_SIZE = 20;
+
+const page = ref(1);
+const newUrl = ref("");
+const { notify, notifyError } = useNotice();
+
+const chat = useAsyncData((signal) => fetchChat(props.chatId, signal));
+const subscriptions = useAsyncData((signal) =>
+  fetchChatRss(props.chatId, page.value, PAGE_SIZE, signal),
+);
+
+watch(page, () => void subscriptions.reload());
+
+const items = computed(() => subscriptions.data.value?.items ?? []);
+const total = computed(() => subscriptions.data.value?.total ?? 0);
+
+/** Which action is in flight: `add`, `toggle:<feedId>` or `remove:<feedId>`. */
+const pending = ref<"add" | `toggle:${number}` | `remove:${number}` | null>(null);
+const busy = computed(() => pending.value !== null);
+
+/** URL field: http(s) with no whitespace, matching the server-side check. */
+const canAdd = computed(() => {
+  if (busy.value) return false;
+  const raw = newUrl.value.trim();
+  return /^https?:\/\/\S+$/.test(raw) && raw.length <= 1024;
+});
+
+function hint(item: RssSubscription): string {
+  const parts = [
+    item.last_fetched_at
+      ? `${t("chats.rssLastFetched")}: ${formatDate(item.last_fetched_at)}`
+      : t("chats.rssNeverFetched"),
+  ];
+  parts.push(
+    item.interval_minutes
+      ? t("chats.rssEvery", { minutes: item.interval_minutes })
+      : t("chats.rssGlobalInterval"),
+  );
+  if (item.last_error) parts.push(t("chats.rssError"));
+  if (item.paused) parts.push(t("chats.rssPaused"));
+  return parts.join(" · ");
+}
+
+function reportError(error: unknown): void {
+  notifyError(isApiError(error) ? tError(error.code) : t("app.loadFailed"));
+}
+
+async function add(): Promise<void> {
+  const url = newUrl.value.trim();
+  if (!canAdd.value) return;
+
+  pending.value = "add";
+  try {
+    await addChatRss(props.chatId, url);
+    newUrl.value = "";
+    notify(t("chats.rssAdded"));
+    haptics.success();
+    await subscriptions.reload();
+  } catch (error) {
+    reportError(error);
+    haptics.error();
+  } finally {
+    pending.value = null;
+  }
+}
+
+/** Pause/resume one feed. The row stays listed either way. */
+async function toggle(item: RssSubscription, paused: boolean): Promise<void> {
+  if (busy.value) return;
+
+  pending.value = `toggle:${item.feed_id}`;
+  try {
+    await setChatRssPaused(props.chatId, item.feed_id, paused);
+    notify(t("app.saved"));
+    haptics.success();
+    await subscriptions.reload();
+  } catch (error) {
+    reportError(error);
+    haptics.error();
+  } finally {
+    pending.value = null;
+  }
+}
+
+async function remove(item: RssSubscription): Promise<void> {
+  const ok = await confirm({
+    title: t("chats.rssRemove"),
+    message: t("chats.rssRemoveConfirm", { name: item.title ?? item.url }),
+    confirmText: t("chats.rssRemove"),
+    destructive: true,
+  });
+  if (!ok) return;
+
+  pending.value = `remove:${item.feed_id}`;
+  try {
+    await deleteChatRss(props.chatId, item.feed_id);
+    notify(t("chats.rssRemoved"));
+    haptics.success();
+    await subscriptions.reload();
+  } catch (error) {
+    reportError(error);
+    haptics.error();
+  } finally {
+    pending.value = null;
+  }
+}
+</script>
+
+<template>
+  <PageHeader :title="t('chats.rss')" :subtitle="chat.data.value?.title" />
+
+  <SettingsSection :label="t('chats.rssAdd')" :hint="t('chats.rssHint')">
+    <TextField
+      v-model="newUrl"
+      :label="t('chats.rssUrl')"
+      :placeholder="t('chats.rssUrlPlaceholder')"
+      inputmode="url"
+      :maxlength="1024"
+    />
+    <SettingsRow
+      :label="t('chats.rssAdd')"
+      navigable
+      :disabled="!canAdd"
+      :busy="pending === 'add'"
+      @click="add"
+    />
+  </SettingsSection>
+
+  <StateBlock
+    :loading="subscriptions.loading.value && !subscriptions.data.value"
+    :error="subscriptions.error.value"
+    :empty="!subscriptions.loading.value && items.length === 0"
+    @retry="subscriptions.reload"
+  >
+    <SettingsSection
+      :label="t('chats.rss')"
+      :hint="items.length ? t('chats.rssActive') : t('chats.rssEmpty')"
+    >
+      <SettingsRow
+        v-for="item in items"
+        :key="item.feed_id"
+        :label="item.title ?? item.url"
+        :hint="hint(item)"
+        :disabled="busy"
+      >
+        <template #control>
+          <ToggleSwitch
+            :model-value="!item.paused"
+            :disabled="busy"
+            :busy="pending === `toggle:${item.feed_id}`"
+            :aria-label="item.paused ? t('chats.rssPaused') : t('chats.rssActive')"
+            @update:model-value="toggle(item, !$event)"
+          />
+        </template>
+      </SettingsRow>
+    </SettingsSection>
+
+    <PagerBar
+      v-model:page="page"
+      :size="PAGE_SIZE"
+      :total="total"
+      :loading="subscriptions.loading.value"
+    />
+
+    <SettingsSection v-if="items.length" :hint="t('chats.rssRemove')">
+      <SettingsRow
+        v-for="item in items"
+        :key="item.feed_id"
+        :label="item.title ?? item.url"
+        :value="t('chats.rssRemove')"
+        navigable
+        destructive
+        :disabled="busy"
+        :busy="pending === `remove:${item.feed_id}`"
+        @click="remove(item)"
+      />
+    </SettingsSection>
+  </StateBlock>
+</template>

--- a/webapp/src/views/me/MyRssView.vue
+++ b/webapp/src/views/me/MyRssView.vue
@@ -1,0 +1,201 @@
+<script setup lang="ts">
+/**
+ * The caller's personal RSS subscriptions (their private chat with the bot).
+ *
+ * Mirror of the group page, scoped to the session user server-side - there is no
+ * chat id anywhere on this page.
+ */
+import { computed, ref, watch } from "vue";
+
+import { addMyRss, deleteMyRss, fetchMyRss, setMyRssPaused } from "@/api/endpoints/me";
+import { isApiError } from "@/api/errors";
+import type { RssSubscription } from "@/api/types";
+import PageHeader from "@/components/PageHeader.vue";
+import PagerBar from "@/components/PagerBar.vue";
+import SettingsRow from "@/components/SettingsRow.vue";
+import SettingsSection from "@/components/SettingsSection.vue";
+import StateBlock from "@/components/StateBlock.vue";
+import TextField from "@/components/TextField.vue";
+import ToggleSwitch from "@/components/ToggleSwitch.vue";
+import { useAsyncData } from "@/composables/useAsyncData";
+import { useNotice } from "@/composables/useNotice";
+import { t, tError } from "@/i18n";
+import { confirm, haptics } from "@/telegram";
+import { formatDate } from "@/utils/format";
+
+const PAGE_SIZE = 20;
+
+const page = ref(1);
+const newUrl = ref("");
+const { notify, notifyError } = useNotice();
+
+const subscriptions = useAsyncData((signal) => fetchMyRss(page.value, PAGE_SIZE, signal));
+
+watch(page, () => void subscriptions.reload());
+
+const items = computed(() => subscriptions.data.value?.items ?? []);
+const total = computed(() => subscriptions.data.value?.total ?? 0);
+
+/** Which action is in flight: `add`, `toggle:<feedId>` or `remove:<feedId>`. */
+const pending = ref<"add" | `toggle:${number}` | `remove:${number}` | null>(null);
+const busy = computed(() => pending.value !== null);
+
+/** URL field: http(s) with no whitespace, matching the server-side check. */
+const canAdd = computed(() => {
+  if (busy.value) return false;
+  const raw = newUrl.value.trim();
+  return /^https?:\/\/\S+$/.test(raw) && raw.length <= 1024;
+});
+
+function hint(item: RssSubscription): string {
+  const parts = [
+    item.last_fetched_at
+      ? `${t("chats.rssLastFetched")}: ${formatDate(item.last_fetched_at)}`
+      : t("chats.rssNeverFetched"),
+  ];
+  parts.push(
+    item.interval_minutes
+      ? t("chats.rssEvery", { minutes: item.interval_minutes })
+      : t("chats.rssGlobalInterval"),
+  );
+  if (item.last_error) parts.push(t("chats.rssError"));
+  if (item.paused) parts.push(t("chats.rssPaused"));
+  return parts.join(" · ");
+}
+
+function reportError(error: unknown): void {
+  notifyError(isApiError(error) ? tError(error.code) : t("app.loadFailed"));
+}
+
+async function add(): Promise<void> {
+  const url = newUrl.value.trim();
+  if (!canAdd.value) return;
+
+  pending.value = "add";
+  try {
+    await addMyRss(url);
+    newUrl.value = "";
+    notify(t("chats.rssAdded"));
+    haptics.success();
+    await subscriptions.reload();
+  } catch (error) {
+    reportError(error);
+    haptics.error();
+  } finally {
+    pending.value = null;
+  }
+}
+
+/** Pause/resume one feed. The row stays listed either way. */
+async function toggle(item: RssSubscription, paused: boolean): Promise<void> {
+  if (busy.value) return;
+
+  pending.value = `toggle:${item.feed_id}`;
+  try {
+    await setMyRssPaused(item.feed_id, paused);
+    notify(t("app.saved"));
+    haptics.success();
+    await subscriptions.reload();
+  } catch (error) {
+    reportError(error);
+    haptics.error();
+  } finally {
+    pending.value = null;
+  }
+}
+
+async function remove(item: RssSubscription): Promise<void> {
+  const ok = await confirm({
+    title: t("chats.rssRemove"),
+    message: t("chats.rssRemoveConfirm", { name: item.title ?? item.url }),
+    confirmText: t("chats.rssRemove"),
+    destructive: true,
+  });
+  if (!ok) return;
+
+  pending.value = `remove:${item.feed_id}`;
+  try {
+    await deleteMyRss(item.feed_id);
+    notify(t("chats.rssRemoved"));
+    haptics.success();
+    await subscriptions.reload();
+  } catch (error) {
+    reportError(error);
+    haptics.error();
+  } finally {
+    pending.value = null;
+  }
+}
+</script>
+
+<template>
+  <PageHeader :title="t('me.rss')" :subtitle="t('me.rssHint')" />
+
+  <SettingsSection :label="t('chats.rssAdd')" :hint="t('chats.rssHint')">
+    <TextField
+      v-model="newUrl"
+      :label="t('chats.rssUrl')"
+      :placeholder="t('chats.rssUrlPlaceholder')"
+      inputmode="url"
+      :maxlength="1024"
+    />
+    <SettingsRow
+      :label="t('chats.rssAdd')"
+      navigable
+      :disabled="!canAdd"
+      :busy="pending === 'add'"
+      @click="add"
+    />
+  </SettingsSection>
+
+  <StateBlock
+    :loading="subscriptions.loading.value && !subscriptions.data.value"
+    :error="subscriptions.error.value"
+    :empty="!subscriptions.loading.value && items.length === 0"
+    @retry="subscriptions.reload"
+  >
+    <SettingsSection
+      :label="t('me.rss')"
+      :hint="items.length ? t('chats.rssActive') : t('chats.rssEmpty')"
+    >
+      <SettingsRow
+        v-for="item in items"
+        :key="item.feed_id"
+        :label="item.title ?? item.url"
+        :hint="hint(item)"
+        :disabled="busy"
+      >
+        <template #control>
+          <ToggleSwitch
+            :model-value="!item.paused"
+            :disabled="busy"
+            :busy="pending === `toggle:${item.feed_id}`"
+            :aria-label="item.paused ? t('chats.rssPaused') : t('chats.rssActive')"
+            @update:model-value="toggle(item, !$event)"
+          />
+        </template>
+      </SettingsRow>
+    </SettingsSection>
+
+    <PagerBar
+      v-model:page="page"
+      :size="PAGE_SIZE"
+      :total="total"
+      :loading="subscriptions.loading.value"
+    />
+
+    <SettingsSection v-if="items.length" :hint="t('chats.rssRemove')">
+      <SettingsRow
+        v-for="item in items"
+        :key="item.feed_id"
+        :label="item.title ?? item.url"
+        :value="t('chats.rssRemove')"
+        navigable
+        destructive
+        :disabled="busy"
+        :busy="pending === `remove:${item.feed_id}`"
+        @click="remove(item)"
+      />
+    </SettingsSection>
+  </StateBlock>
+</template>

--- a/webapp/src/views/me/ProfileView.vue
+++ b/webapp/src/views/me/ProfileView.vue
@@ -190,6 +190,12 @@ async function onRefreshAvatar(): Promise<void> {
         navigable
         @click="router.push({ name: 'chats' })"
       />
+      <SettingsRow
+        :label="t('me.rss')"
+        :hint="t('me.rssHint')"
+        navigable
+        @click="router.push({ name: 'me-rss' })"
+      />
     </SettingsSection>
 
     <SettingsSection :label="t('me.avatar')">


### PR DESCRIPTION
- Added /rss bot command with sub, list, pause, resume, interval, and testpush subcommands.
- Added per-minute poll job that fetches due feeds and pushes new entries to subscribed chats.
- Added feed service with SSRF guard, conditional GET, media extraction, and Telegram-safe HTML sanitizer.
- Added chat and personal subscription APIs plus panel views for managing feeds.
- Added rss_allowed chat policy flag with admin panel toggle and whitelist config.
- Added alembic migration and comprehensive test suite covering storage, service, and APIs.