### PR TITLE
fix(client): prevent dead-locked Telegram session from freezing the bot

### DIFF
--- a/kmua/__main__.py
+++ b/kmua/__main__.py
@@ -336,6 +336,7 @@ async def main():
             failure_threshold=app_config.session_health_threshold,
             cooldown=app_config.session_health_cooldown,
             stale_threshold=app_config.session_health_stale,
+            restart_timeout=app_config.session_health_restart_timeout,
         )
         session_health.start()
 

--- a/kmua/bot/client.py
+++ b/kmua/bot/client.py
@@ -2,8 +2,23 @@ from os import cpu_count
 from pathlib import Path
 
 from pyrogram.client import Client
+from pyrogram.session import Session
 
 from kmua.config import app_config
+
+# kurigram/pyrogram serialize ALL MTProto crypto through a single
+# ThreadPoolExecutor worker per session (Session.CRYPTO_EXECUTOR_WORKERS = 1):
+# every outgoing request (mtproto.pack in session.send) and every incoming
+# packet (mtproto.unpack in session.handle_packet) parks on that one thread,
+# with no timeout on either await. Under concurrent file transfers (see
+# max_concurrent_transmissions below) the queue saturates, WAIT_TIMEOUT (15s)
+# fires for every invoke, and each retry re-enqueues more work - the backlog
+# becomes self-sustaining and the session wedges (no updates, all calls time
+# out) while the process stays alive. pack/unpack are pure functions of their
+# inputs, so a few workers are safe and remove the single point of failure.
+# setattr: the class attribute is inferred as Literal[1], so a direct
+# assignment would be a type error in pyright/pyrefly.
+setattr(Session, "CRYPTO_EXECUTOR_WORKERS", min(4, cpu_count() or 1))
 
 
 def _build_plugins_config() -> dict[str, object]:

--- a/kmua/common/avatar.py
+++ b/kmua/common/avatar.py
@@ -27,8 +27,21 @@ def _get_avatar_path(user_id: int, big: bool = True) -> Path:
     )
 
 
+# A burst of avatar cache misses (quotes, waifu cards) must not flood the
+# Telegram session: refreshes are serialized through a small semaphore, each
+# one is hard-timed, and a failure is remembered so hot paths back off for a
+# while instead of retrying a dead session on every call.
+_avatar_refresh_semaphore = asyncio.Semaphore(
+    max(1, app_config.avatar_refresh_concurrency)
+)
+_avatar_refresh_failed_at: dict[int, float] = {}
+
+
 async def _get_avatar_bytes(
-    chat_id: int, big: bool = True, force_refresh: bool = False
+    chat_id: int,
+    big: bool = True,
+    force_refresh: bool = False,
+    ignore_backoff: bool = False,
 ) -> tuple[bytes | None, bool]:
     """Get avatar bytes for a chat.
     Returns:
@@ -41,19 +54,38 @@ async def _get_avatar_bytes(
     if await aiofiles.os.path.exists(avatar_path) and not force_refresh:
         async with aiofiles.open(avatar_path, "rb") as avatar_file:
             return (await avatar_file.read(), False)
-    chat_full = await client.get_chat(chat_id, True)
-    if not chat_full.photo:
+    loop = asyncio.get_running_loop()
+    if (
+        not ignore_backoff
+        and loop.time() - _avatar_refresh_failed_at.get(chat_id, 0.0)
+        < app_config.avatar_refresh_retry_after
+    ):
+        # A recent refresh attempt failed; don't hammer the session again.
         return None, False
-    photo_id = chat_full.photo.big_file_id if big else chat_full.photo.small_file_id
-    file = await client.download_media(photo_id, in_memory=True)
-    if not file or not isinstance(file, BytesIO):
-        return None, False
-    file.seek(0)
-    avatar = file.read()
-    await aiofiles.os.makedirs(avatar_path.parent, exist_ok=True)
-    async with aiofiles.open(avatar_path, "wb") as avatar_file:
-        await avatar_file.write(avatar)
-    return avatar, True
+    try:
+        async with _avatar_refresh_semaphore:
+            async with asyncio.timeout(app_config.avatar_refresh_timeout):
+                chat_full = await client.get_chat(chat_id, True)
+                if not chat_full.photo:
+                    return None, False
+                photo_id = (
+                    chat_full.photo.big_file_id
+                    if big
+                    else chat_full.photo.small_file_id
+                )
+                file = await client.download_media(photo_id, in_memory=True)
+                if not file or not isinstance(file, BytesIO):
+                    return None, False
+                file.seek(0)
+                avatar = file.read()
+                await aiofiles.os.makedirs(avatar_path.parent, exist_ok=True)
+                async with aiofiles.open(avatar_path, "wb") as avatar_file:
+                    await avatar_file.write(avatar)
+                _avatar_refresh_failed_at.pop(chat_id, None)
+                return avatar, True
+    except Exception:
+        _avatar_refresh_failed_at[chat_id] = loop.time()
+        raise
 
 
 class ChatAvatar:
@@ -108,16 +140,17 @@ class ChatAvatar:
                     force_refresh = True
                 if force_refresh:
                     logger.debug(f"Refreshing avatar for chat {self.chat_id}")
-                    avatar_b, _ = await _get_avatar_bytes(
-                        self.chat_id, big=True, force_refresh=True
-                    )
-                    avatar_s, _ = await _get_avatar_bytes(
-                        self.chat_id, big=False, force_refresh=True
+                    # Refresh only the requested size; the other size is
+                    # refreshed lazily on its own first use. Downloading both
+                    # here doubles the network load for callers that only need
+                    # one (quote/waifu hot paths).
+                    avatar, _ = await _get_avatar_bytes(
+                        self.chat_id, big=big, force_refresh=True
                     )
                     await database.update_user_avatar(
                         user_id=self.chat_id, refreshed=True
                     )
-                    return avatar_b if big else avatar_s
+                    return avatar
                 else:
                     avatar, _ = await _get_avatar_bytes(self.chat_id, big=big)
                     return avatar
@@ -178,11 +211,13 @@ class ChatAvatar:
     async def force_refresh(self) -> bool:
         try:
             async with self._lock:
+                # Explicit user action: always try, even if a recent refresh
+                # attempt failed (backoff is for the hot paths only).
                 avatar_b, refreshed_big = await _get_avatar_bytes(
-                    self.chat_id, big=True, force_refresh=True
+                    self.chat_id, big=True, force_refresh=True, ignore_backoff=True
                 )
                 avatar_s, refreshed_small = await _get_avatar_bytes(
-                    self.chat_id, big=False, force_refresh=True
+                    self.chat_id, big=False, force_refresh=True, ignore_backoff=True
                 )
                 if all((avatar_b, avatar_s, refreshed_big, refreshed_small)):
                     await database.update_user_avatar(

--- a/kmua/config/__init__.py
+++ b/kmua/config/__init__.py
@@ -100,6 +100,10 @@ class _AppConfig(pydantic.BaseModel):
     session_health_timeout: float = 15.0  # probe invoke timeout
     session_health_threshold: int = 3  # consecutive failures before restart
     session_health_cooldown: float = 60.0  # min seconds between restarts
+    # Hard cap for a forced session.restart(); a hung restart (kurigram can
+    # block inside stop() on its single crypto thread) must not block the
+    # monitor forever.
+    session_health_restart_timeout: float = 90.0
     # If no update arrives within this many seconds, the recv path is
     # considered dead (half-open TCP) and a restart is forced.
     session_health_stale: float = 300.0
@@ -264,6 +268,15 @@ class _AppConfig(pydantic.BaseModel):
     cachedir: Path = workdir / "cache"
     avatar_cache_dir: Path = cachedir / "avatar"
     avatar_expire: int = 60 * 60 * 24  # 1 day
+    # Cap concurrent avatar network refreshes (get_chat + download_media), so a
+    # burst of cache misses (quote/waifu hot paths) cannot flood the Telegram
+    # session with parallel file downloads.
+    avatar_refresh_concurrency: int = 3
+    # Hard timeout for one avatar refresh. Failures are remembered for
+    # avatar_refresh_retry_after seconds so hot paths fall back to the cached/
+    # default avatar instead of retrying a dead session on every call.
+    avatar_refresh_timeout: float = 30.0
+    avatar_refresh_retry_after: float = 10 * 60
 
     # coin cost
     cost_user_change_waifu_base: int = 16

--- a/kmua/session_health.py
+++ b/kmua/session_health.py
@@ -16,8 +16,11 @@ This monitor uses two signals:
    interval), the recv path is likely dead even if invokes still succeed
    (half-open TCP).
 
-When either signal fails repeatedly, the monitor force-restarts the main
-session.
+When either signal fails repeatedly, the monitor force-restarts the session.
+Besides the main session, every cached media/other-DC session is probed the
+same way: kurigram reuses those sessions forever and pings them without
+checking responses, so a dead media session (failed uploads/downloads, e.g.
+avatar refreshes) would otherwise never recover.
 """
 
 import asyncio
@@ -38,6 +41,8 @@ class SessionHealthMonitor:
         failure_threshold: int = 3,
         cooldown: float = 60.0,
         stale_threshold: float = 300.0,
+        restart_timeout: float = 90.0,
+        probe_grace: float = 5.0,
     ) -> None:
         """
         Args:
@@ -48,6 +53,10 @@ class SessionHealthMonitor:
             cooldown: Minimum seconds between forced restarts.
             stale_threshold: If no update arrives within this many seconds,
                 the recv path is considered dead (half-open TCP).
+            restart_timeout: Hard cap for a forced session.restart() call.
+            probe_grace: Extra seconds allowed on top of probe_timeout before a
+                probe is declared dead (kurigram's internal send has no
+                timeout on its crypto-executor await).
         """
         self.client = client
         self.check_interval = check_interval
@@ -55,28 +64,37 @@ class SessionHealthMonitor:
         self.failure_threshold = failure_threshold
         self.cooldown = cooldown
         self.stale_threshold = stale_threshold
+        self.restart_timeout = restart_timeout
+        self.probe_grace = probe_grace
         self._task: asyncio.Task | None = None
         self._stop = False
         self._consecutive_failures = 0
         self._stale_count = 0
         self._last_restart = 0.0
+        # Per-secondary-session failure / restart bookkeeping, keyed by
+        # id(session) so it survives dict churn.
+        self._media_failures: dict[int, int] = {}
+        self._media_last_restart: dict[int, float] = {}
 
-    async def _probe_invoke(self) -> bool:
-        """Probe the send path. Returns True if the invoke succeeds."""
+    async def _probe_session(self, session) -> bool:
+        """Probe one session's send path. Returns True if the invoke succeeds."""
         try:
-            session = self.client.session
-            if session is None:
-                return False
-            await session.invoke(
-                raw.functions.updates.GetState(),
-                retries=1,
-                timeout=self.probe_timeout,
+            # kurigram's session.send/handle_packet await run_in_executor (the
+            # single crypto thread) WITHOUT a timeout; when that queue is
+            # congested the invoke can hang past its own timeout. Hard-cap the
+            # whole probe so a wedged session can never hang this monitor.
+            await asyncio.wait_for(
+                session.invoke(
+                    raw.functions.updates.GetState(),
+                    retries=1,
+                    timeout=self.probe_timeout,
+                ),
+                timeout=self.probe_timeout + self.probe_grace,
             )
             return True
         except Exception as e:
             logger.debug(
-                f"session_health: invoke probe failed: "
-                f"{e.__class__.__name__} - {e}"
+                f"session_health: invoke probe failed: {e.__class__.__name__} - {e}"
             )
             return False
 
@@ -88,25 +106,31 @@ class SessionHealthMonitor:
         elapsed = (datetime.now() - last).total_seconds()
         return elapsed > self.stale_threshold
 
-    async def _force_restart(self, reason: str) -> None:
-        logger.warning(
-            f"session_health: forcing session restart (reason: {reason})"
-        )
-        session = self.client.session
-        if session is None:
-            logger.error("session_health: no session to restart")
-            return
+    async def _restart_session(self, session, reason: str) -> bool:
+        """Force-restart one session. Returns True on success."""
+        logger.warning(f"session_health: forcing session restart (reason: {reason})")
         try:
-            await session.restart()
-            # Reset last_update_time so we don't immediately re-trigger
-            # staleness while the session reconnects.
-            self.client.last_update_time = datetime.now()
+            # Bound the restart: kurigram's restart() can hang inside stop()
+            # (its final ping send awaits the crypto executor without a
+            # timeout) while holding restart_lock, which would permanently
+            # block every later recovery attempt - including this one. On
+            # timeout the cancelled restart unwinds and releases the lock, so
+            # the next check cycle can try again.
+            await asyncio.wait_for(session.restart(), timeout=self.restart_timeout)
             logger.success("session_health: session restarted successfully")
+            return True
+        except TimeoutError:
+            logger.error(
+                "session_health: session restart hung for "
+                f">{self.restart_timeout:.0f}s (crypto executor wedged?); "
+                "will retry on the next check cycle"
+            )
+            return False
         except Exception as e:
             logger.error(
-                f"session_health: restart failed: "
-                f"{e.__class__.__name__} - {e}"
+                f"session_health: restart failed: {e.__class__.__name__} - {e}"
             )
+            return False
 
     async def _loop(self) -> None:
         loop = asyncio.get_running_loop()
@@ -118,78 +142,135 @@ class SessionHealthMonitor:
             if self._stop or not self.client.is_connected:
                 continue
 
-            # --- Signal 1: invoke probe (send path) ---
-            invoke_ok = await self._probe_invoke()
-            if invoke_ok:
-                if self._consecutive_failures > 0:
-                    logger.info(
-                        "session_health: invoke path recovered after "
-                        f"{self._consecutive_failures} failure(s)"
-                    )
-                self._consecutive_failures = 0
-            else:
-                self._consecutive_failures += 1
-                logger.warning(
-                    f"session_health: invoke probe failed "
-                    f"({self._consecutive_failures}/{self.failure_threshold})"
+            try:
+                await self._check_once(loop)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                # A watchdog that dies is worse than a wrong verdict: keep the
+                # loop alive no matter what a single check throws.
+                logger.error(
+                    f"session_health: check failed: {e.__class__.__name__} - {e}"
                 )
 
-            # --- Signal 2: update staleness (recv path) ---
-            stale = self._is_stale()
-            if stale:
-                self._stale_count += 1
-                last = getattr(self.client, "last_update_time", None)
-                elapsed = (
-                    (datetime.now() - last).total_seconds() if last else -1
-                )
-                logger.warning(
-                    f"session_health: no updates for {elapsed:.0f}s "
-                    f"(stale count: {self._stale_count})"
-                )
-            else:
-                if self._stale_count > 0:
-                    logger.info(
-                        "session_health: updates resumed after "
-                        f"{self._stale_count} stale check(s)"
-                    )
-                self._stale_count = 0
+    async def _check_once(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Run one health-check cycle (probe + staleness + possible restarts)."""
+        main_session = self.client.session
 
-            # --- Decide whether to force restart ---
-            should_restart = (
-                self._consecutive_failures >= self.failure_threshold
-                or self._stale_count >= self.failure_threshold
+        # --- Main session: invoke probe (send path) ---
+        invoke_ok = main_session is not None and await self._probe_session(main_session)
+        if invoke_ok:
+            if self._consecutive_failures > 0:
+                logger.info(
+                    "session_health: invoke path recovered after "
+                    f"{self._consecutive_failures} failure(s)"
+                )
+            self._consecutive_failures = 0
+        else:
+            self._consecutive_failures += 1
+            logger.warning(
+                f"session_health: invoke probe failed "
+                f"({self._consecutive_failures}/{self.failure_threshold})"
             )
-            if not should_restart:
-                continue
 
+        # --- Main session: update staleness (recv path) ---
+        stale = self._is_stale()
+        if stale:
+            self._stale_count += 1
+            last = getattr(self.client, "last_update_time", None)
+            elapsed = (datetime.now() - last).total_seconds() if last else -1
+            logger.warning(
+                f"session_health: no updates for {elapsed:.0f}s "
+                f"(stale count: {self._stale_count})"
+            )
+        else:
+            if self._stale_count > 0:
+                logger.info(
+                    "session_health: updates resumed after "
+                    f"{self._stale_count} stale check(s)"
+                )
+            self._stale_count = 0
+
+        # --- Main session: decide whether to force restart ---
+        should_restart = (
+            self._consecutive_failures >= self.failure_threshold
+            or self._stale_count >= self.failure_threshold
+        )
+        if should_restart and main_session is not None:
             now = loop.time()
             if now - self._last_restart < self.cooldown:
                 logger.debug("session_health: in cooldown, skipping restart")
+            else:
+                reason_parts = []
+                if self._consecutive_failures >= self.failure_threshold:
+                    reason_parts.append(f"invoke failed {self._consecutive_failures}x")
+                if self._stale_count >= self.failure_threshold:
+                    reason_parts.append(f"updates stale {self._stale_count}x")
+                reason = ", ".join(reason_parts)
+
+                self._last_restart = now
+                self._consecutive_failures = 0
+                self._stale_count = 0
+                if await self._restart_session(main_session, reason):
+                    # Reset last_update_time so we don't immediately re-trigger
+                    # staleness while the session reconnects.
+                    self.client.last_update_time = datetime.now()
+
+        # --- Secondary (media / other-DC) sessions ---
+        # kurigram reuses cached sessions forever and pings them with
+        # wait_response=False, so a silently-dead media session (the
+        # upload.GetFile/avatar-refresh failures) never recovers on its own.
+        for session in self._secondary_sessions():
+            if not session.is_started.is_set():
                 continue
-
-            reason_parts = []
-            if self._consecutive_failures >= self.failure_threshold:
-                reason_parts.append(
-                    f"invoke failed {self._consecutive_failures}x"
+            key = id(session)
+            if await self._probe_session(session):
+                if key in self._media_failures:
+                    logger.info(
+                        f"session_health: session DC{session.dc_id} recovered after "
+                        f"{self._media_failures.pop(key)} failure(s)"
+                    )
+                continue
+            failures = self._media_failures.get(key, 0) + 1
+            self._media_failures[key] = failures
+            if failures < self.failure_threshold:
+                logger.warning(
+                    f"session_health: session DC{session.dc_id} probe failed "
+                    f"({failures}/{self.failure_threshold})"
                 )
-            if self._stale_count >= self.failure_threshold:
-                reason_parts.append(
-                    f"updates stale {self._stale_count}x"
+                continue
+            now = loop.time()
+            if now - self._media_last_restart.get(key, 0.0) < self.cooldown:
+                logger.debug(
+                    f"session_health: session DC{session.dc_id} in cooldown, "
+                    "skipping restart"
                 )
-            reason = ", ".join(reason_parts)
+                continue
+            self._media_last_restart[key] = now
+            self._media_failures.pop(key, None)
+            await self._restart_session(
+                session,
+                reason=f"session DC{session.dc_id} invoke failed {failures}x",
+            )
 
-            self._last_restart = now
-            self._consecutive_failures = 0
-            self._stale_count = 0
-            await self._force_restart(reason)
+    def _secondary_sessions(self) -> list:
+        """Cached non-main sessions (media sessions and other-DC sessions)."""
+        sessions = []
+        seen: set[int] = set()
+        main = self.client.session
+        for pool in (self.client.sessions, self.client.media_sessions):
+            for session in pool.values():
+                if session is main or id(session) in seen:
+                    continue
+                seen.add(id(session))
+                sessions.append(session)
+        return sessions
 
     def start(self) -> None:
         if self._task is not None and not self._task.done():
             return
         self._stop = False
-        self._task = asyncio.create_task(
-            self._loop(), name="session-health-monitor"
-        )
+        self._task = asyncio.create_task(self._loop(), name="session-health-monitor")
         logger.info(
             f"Session health monitor started "
             f"(interval={self.check_interval}s, timeout={self.probe_timeout}s, "

--- a/kmua/webapp/sanitize.py
+++ b/kmua/webapp/sanitize.py
@@ -57,6 +57,7 @@ _PUBLIC_FIELDS: dict[str, tuple[str, ...]] = {
         "session_health_threshold",
         "session_health_cooldown",
         "session_health_stale",
+        "session_health_restart_timeout",
     ),
     "agent": (
         "agent",

--- a/tests/test_avatar.py
+++ b/tests/test_avatar.py
@@ -1,0 +1,170 @@
+"""Avatar cache hot-path tests.
+
+Quotes and waifu cards hit ``ChatAvatar`` on every use; a burst of cache
+misses used to fan out into unbounded parallel ``get_chat`` + ``download_media``
+calls (the "avatar refresh storm" that congests the Telegram session). These
+tests pin the contracts that bound the storm at the call path:
+
+- a failed refresh is remembered, and hot paths back off for
+  ``avatar_refresh_retry_after`` seconds instead of retrying a dead session
+  on every call;
+- the backoff expires, so the avatar self-heals after the outage;
+- explicit ``force_refresh()`` bypasses the backoff;
+- refreshing one size does not download the other size.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+from datetime import datetime, timedelta
+
+import pytest
+
+from kmua.common import avatar as avatar_mod
+from kmua.config import app_config
+
+
+class _Photo:
+    big_file_id = "big-id"
+    small_file_id = "small-id"
+
+
+class _ChatFull:
+    def __init__(self) -> None:
+        self.photo = _Photo()
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.get_chat_calls = 0
+        self.download_calls = 0
+        self.fail = False
+
+    async def get_chat(self, chat_id, full=False):
+        self.get_chat_calls += 1
+        if self.fail:
+            raise TimeoutError("Request timed out")
+        return _ChatFull()
+
+    async def download_media(self, file_id, in_memory=False):
+        self.download_calls += 1
+        return io.BytesIO(b"avatar-bytes")
+
+
+class _User:
+    def __init__(self, user_id: int) -> None:
+        self.id = user_id
+        self.update_avatar_at = datetime.now() - timedelta(days=2)
+        self.avatar_big_id = None
+
+
+@pytest.fixture
+def fake_client(monkeypatch) -> _FakeClient:
+    client = _FakeClient()
+    monkeypatch.setattr(avatar_mod, "client", client)
+    yield client
+    avatar_mod._avatar_refresh_failed_at.clear()
+
+
+@pytest.fixture
+def fake_db(monkeypatch) -> dict[int, _User]:
+    users: dict[int, _User] = {}
+
+    async def get_user_by_id(user_id: int):
+        return users.get(user_id)
+
+    async def update_user_avatar(
+        user_id: int,
+        avatar_big_id: str | None = None,
+        refreshed: bool = False,
+        session=None,
+    ):
+        user = users.get(user_id)
+        if user is None:
+            raise ValueError(f"User with id {user_id} not found")
+        user.avatar_big_id = avatar_big_id
+        if refreshed:
+            user.update_avatar_at = datetime.now()
+
+    monkeypatch.setattr(avatar_mod.database, "get_user_by_id", get_user_by_id)
+    monkeypatch.setattr(avatar_mod.database, "update_user_avatar", update_user_avatar)
+    return users
+
+
+@pytest.fixture
+def avatar_cache_dir(tmp_path, monkeypatch) -> object:
+    monkeypatch.setattr(app_config, "avatar_cache_dir", tmp_path)
+    return tmp_path
+
+
+async def test_failed_refresh_backs_off(fake_client: _FakeClient) -> None:
+    fake_client.fail = True
+    with pytest.raises(TimeoutError):
+        await avatar_mod._get_avatar_bytes(123, force_refresh=True)
+    assert fake_client.get_chat_calls == 1
+
+    # Second call within the retry window: no network at all.
+    avatar, refreshed = await avatar_mod._get_avatar_bytes(123, force_refresh=True)
+    assert avatar is None and refreshed is False
+    assert fake_client.get_chat_calls == 1
+
+
+async def test_backoff_expires_after_retry_after(
+    fake_client: _FakeClient, avatar_cache_dir
+) -> None:
+    fake_client.fail = True
+    with pytest.raises(TimeoutError):
+        await avatar_mod._get_avatar_bytes(123, force_refresh=True)
+
+    loop = asyncio.get_running_loop()
+    avatar_mod._avatar_refresh_failed_at[123] = (
+        loop.time() - app_config.avatar_refresh_retry_after - 1
+    )
+    fake_client.fail = False
+
+    avatar, refreshed = await avatar_mod._get_avatar_bytes(123, force_refresh=True)
+    assert avatar == b"avatar-bytes" and refreshed is True
+    assert fake_client.get_chat_calls == 2
+
+
+async def test_force_refresh_bypasses_backoff(
+    fake_client: _FakeClient, avatar_cache_dir
+) -> None:
+    fake_client.fail = True
+    with pytest.raises(TimeoutError):
+        await avatar_mod._get_avatar_bytes(123, force_refresh=True, ignore_backoff=True)
+    with pytest.raises(TimeoutError):
+        await avatar_mod._get_avatar_bytes(123, force_refresh=True, ignore_backoff=True)
+    assert fake_client.get_chat_calls == 2
+
+
+async def test_save_if_not_exists_backs_off(
+    fake_client: _FakeClient, avatar_cache_dir
+) -> None:
+    fake_client.fail = True
+    await avatar_mod.ChatAvatar(123).save_if_not_exists()
+    assert fake_client.get_chat_calls == 1
+
+    await avatar_mod.ChatAvatar(123).save_if_not_exists()
+    assert fake_client.get_chat_calls == 1  # backoff, no retry
+
+
+async def test_get_bytes_refreshes_only_requested_size(
+    fake_client: _FakeClient,
+    fake_db: dict[int, _User],
+    avatar_cache_dir,
+) -> None:
+    fake_db[999] = _User(999)
+    cache_dir = avatar_cache_dir
+
+    avatar = await avatar_mod.ChatAvatar(999).get_bytes(big=True)
+    assert avatar == b"avatar-bytes"
+    assert fake_client.download_calls == 1  # only big downloaded
+    assert not (cache_dir / "99" / "999_small.jpg").exists()
+
+    # The other size is refreshed lazily on its own first use.
+    small = await avatar_mod.ChatAvatar(999).get_bytes(big=False)
+    assert small == b"avatar-bytes"
+    assert fake_client.download_calls == 2
+    assert (cache_dir / "99" / "999_small.jpg").exists()

--- a/tests/test_session_health.py
+++ b/tests/test_session_health.py
@@ -1,0 +1,227 @@
+"""Session health monitor tests.
+
+The monitor is the last line of defense against kurigram zombie sessions: a
+silently-dead TCP connection leaves the session "started" but unreachable, and
+the library's own recovery paths can hang forever (single crypto-executor
+thread, unbounded run_in_executor awaits, restart_lock held by a stuck
+restart). These tests pin the contracts that keep the watchdog itself alive:
+
+- every probe and every forced restart is hard-bounded, even when the
+  underlying library call never returns;
+- a failing media/other-DC session is force-restarted after the failure
+  threshold (kurigram reuses those sessions forever and never recovers them);
+- a main session that stops receiving updates (staleness) is force-restarted,
+  and a successful restart resets the staleness clock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta
+
+import pytest
+
+from kmua.session_health import SessionHealthMonitor
+
+
+class _FakeSession:
+    def __init__(self, dc_id: int = 1, invoke_ok: bool = True) -> None:
+        self.dc_id = dc_id
+        self.is_started = asyncio.Event()
+        self.is_started.set()
+        self.invoke_ok = invoke_ok
+        self.invoke_calls = 0
+        self.restart_calls = 0
+        self._hang_invoke = asyncio.Event()
+        self._hang_restart = asyncio.Event()
+        self._never = asyncio.Event()
+
+    async def invoke(self, *args, **kwargs):
+        self.invoke_calls += 1
+        if self._hang_invoke.is_set():
+            await self._never.wait()  # never returns
+        if not self.invoke_ok:
+            raise TimeoutError("Request timed out")
+        return None
+
+    async def restart(self):
+        self.restart_calls += 1
+        if self._hang_restart.is_set():
+            await self._never.wait()  # never returns
+        return None
+
+
+class _FakeClient:
+    def __init__(self, main: _FakeSession) -> None:
+        self.session = main
+        self.sessions: dict[int, _FakeSession] = {}
+        self.media_sessions: dict[int, _FakeSession] = {}
+        self.is_connected = True
+        self.last_update_time = datetime.now()
+
+
+def _monitor(
+    client: _FakeClient,
+    probe_timeout: float = 1.0,
+    probe_grace: float = 0.2,
+    failure_threshold: int = 3,
+    cooldown: float = 0.0,
+    stale_threshold: float = 300.0,
+    restart_timeout: float = 1.0,
+) -> SessionHealthMonitor:
+    return SessionHealthMonitor(
+        client=client,
+        check_interval=60.0,
+        probe_timeout=probe_timeout,
+        probe_grace=probe_grace,
+        failure_threshold=failure_threshold,
+        cooldown=cooldown,
+        stale_threshold=stale_threshold,
+        restart_timeout=restart_timeout,
+    )
+
+
+async def _elapsed(fn) -> tuple[object, float]:
+    start = asyncio.get_running_loop().time()
+    result = await fn()
+    return result, asyncio.get_running_loop().time() - start
+
+
+async def test_probe_bounded_when_invoke_hangs() -> None:
+    """A wedged crypto queue must not hang the monitor's probe forever."""
+    session = _FakeSession()
+    monitor = _monitor(_FakeClient(session), probe_timeout=0.1, probe_grace=0.2)
+    session._hang_invoke.set()
+
+    ok, elapsed = await _elapsed(lambda: monitor._probe_session(session))
+
+    assert ok is False
+    assert elapsed < 1.0  # cap is probe_timeout + probe_grace = 0.3s
+
+
+async def test_restart_bounded_when_restart_hangs() -> None:
+    """A stuck library restart must time out and report failure, not block."""
+    session = _FakeSession()
+    monitor = _monitor(_FakeClient(session), restart_timeout=0.2)
+    session._hang_restart.set()
+
+    ok, elapsed = await _elapsed(lambda: monitor._restart_session(session, "test"))
+
+    assert ok is False
+    assert elapsed < 1.0
+
+
+async def test_media_session_restarted_after_failure_threshold() -> None:
+    """A silently-dead media session is force-restarted after N failures."""
+    main = _FakeSession()
+    media = _FakeSession(dc_id=2, invoke_ok=False)
+    client = _FakeClient(main)
+    client.media_sessions[2] = media
+    monitor = _monitor(client, failure_threshold=3)
+    loop = asyncio.get_running_loop()
+
+    for _ in range(3):
+        await monitor._check_once(loop)
+
+    assert media.restart_calls == 1
+    assert media.invoke_calls == 3
+    assert main.restart_calls == 0
+
+
+async def test_media_session_not_restarted_below_threshold() -> None:
+    """One probe hiccup is not enough to restart a session."""
+    main = _FakeSession()
+    media = _FakeSession(dc_id=2, invoke_ok=False)
+    client = _FakeClient(main)
+    client.media_sessions[2] = media
+    monitor = _monitor(client, failure_threshold=3)
+    loop = asyncio.get_running_loop()
+
+    await monitor._check_once(loop)
+
+    assert media.restart_calls == 0
+
+
+async def test_media_session_recovers_and_clears_failure_count() -> None:
+    """A session that recovers stops accumulating failures."""
+    main = _FakeSession()
+    media = _FakeSession(dc_id=2, invoke_ok=False)
+    client = _FakeClient(main)
+    client.media_sessions[2] = media
+    monitor = _monitor(client, failure_threshold=3)
+    loop = asyncio.get_running_loop()
+
+    await monitor._check_once(loop)  # failure 1
+    await monitor._check_once(loop)  # failure 2
+    media.invoke_ok = True
+    await monitor._check_once(loop)  # recovery
+
+    assert media.restart_calls == 0
+    assert monitor._media_failures == {}
+
+
+async def test_stale_main_session_triggers_restart_and_resets_clock() -> None:
+    """No updates for longer than stale_threshold force-restarts the session."""
+    main = _FakeSession()
+    client = _FakeClient(main)
+    client.last_update_time = datetime.now() - timedelta(seconds=1000)
+    monitor = _monitor(client, failure_threshold=3, stale_threshold=300)
+    loop = asyncio.get_running_loop()
+
+    for _ in range(3):
+        await monitor._check_once(loop)
+
+    assert main.restart_calls == 1
+    # A successful restart resets the staleness clock...
+    assert datetime.now() - client.last_update_time < timedelta(seconds=1)
+    # ...so the next cycle does not immediately re-trigger.
+    await monitor._check_once(loop)
+    assert main.restart_calls == 1
+
+
+async def test_healthy_main_session_never_restarts() -> None:
+    main = _FakeSession()
+    client = _FakeClient(main)
+    monitor = _monitor(client)
+    loop = asyncio.get_running_loop()
+
+    for _ in range(3):
+        await monitor._check_once(loop)
+
+    assert main.restart_calls == 0
+
+
+async def test_secondary_sessions_collects_media_and_other_dc() -> None:
+    main = _FakeSession()
+    media = _FakeSession(dc_id=2)
+    other = _FakeSession(dc_id=3)
+    client = _FakeClient(main)
+    client.media_sessions[2] = media
+    client.sessions[3] = other
+    monitor = _monitor(client)
+
+    sessions = monitor._secondary_sessions()
+
+    assert sessions == [other, media]
+    # The main session is never probed twice.
+    assert main not in sessions
+
+
+@pytest.mark.parametrize(
+    "pool_attr",
+    ["sessions", "media_sessions"],
+)
+async def test_secondary_session_probed_but_not_restarted_when_healthy(
+    pool_attr: str,
+) -> None:
+    main = _FakeSession()
+    secondary = _FakeSession(dc_id=2)
+    client = _FakeClient(main)
+    getattr(client, pool_attr)[2] = secondary
+    monitor = _monitor(client)
+    loop = asyncio.get_running_loop()
+
+    await monitor._check_once(loop)
+
+    assert secondary.invoke_calls == 1
+    assert secondary.restart_calls == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1995,7 +1995,7 @@ dev = [
 [[package]]
 name = "kurigram"
 version = "2.2.24"
-source = { git = "https://github.com/KurimuzonAkuma/kurigram.git#5826bce63ab6708d9e23f5857494611565a4ca75" }
+source = { git = "https://github.com/KurimuzonAkuma/kurigram.git#f051c8e8ce82f6c70ff12424746425c688434ec3" }
 dependencies = [
     { name = "pyaes" },
     { name = "python-socks" },


### PR DESCRIPTION
The bot stopped receiving updates while the process stayed alive and the webapp kept working. kurigram serializes ALL MTProto crypto (pack of every outgoing request, unpack of every incoming packet) through one ThreadPoolExecutor worker per session with no timeout on either await. Under concurrent file transfers the queue saturates, every invoke times out, and each retry re-enqueues more work; recovery dead-locks when a restart() hangs in stop() on the same queue while holding restart_lock, and the session-health watchdog could hang in its own unbounded probe. The avatar refresh storm (quotes / waifu cards) was the main trigger.

- client: raise Session.CRYPTO_EXECUTOR_WORKERS to min(4, cpu_count) (pack/unpack are pure functions of their inputs; setattr used because the attribute is inferred as Literal[1])
- session_health: hard-bound probes (probe_timeout + grace) and forced restarts (restart_timeout); keep the watchdog loop alive on errors; probe and force-restart cached media/other-DC sessions, which kurigram reuses forever and never recovers on its own
- avatar: cap concurrent refreshes with a semaphore, hard-time each refresh, back off 10 min after a failure so hot paths stop retrying a dead session, and refresh only the requested image size
- deps: bump kurigram 5826bce -> f051c8e8 (Bot API 10.2 features; no session internals changed)
- config: session_health_restart_timeout, avatar_refresh_concurrency, avatar_refresh_timeout, avatar_refresh_retry_after
- tests: session-health watchdog contracts, avatar hot-path contracts