### PR TITLE
feat(rss): added per-chat AI digests and broadcasts for feed pushes

### DIFF
--- a/kmua/bot/jobs.py
+++ b/kmua/bot/jobs.py
@@ -1,4 +1,5 @@
 import asyncio
+import html
 import io
 import random
 from datetime import UTC, datetime, timedelta
@@ -9,6 +10,7 @@ import pyrogram.errors
 
 from kmua import common, database, enums, i18n
 from kmua.config import app_config
+from kmua.database.models import ChatConfig
 from kmua.logger import logger
 
 
@@ -169,13 +171,73 @@ async def rss_push():
         for chat_id in chat_ids:
             if chat_id not in lang_by_chat:
                 lang_by_chat[chat_id] = await _chat_lang(chat_id)
+
+        # Per-chat agent switches: summary digests are generated once per
+        # language (a feed usually fans out to several chats), broadcasts once
+        # per broadcast-enabled group chat.
+        chat_configs: dict[int, ChatConfig] = {}
+        summary_langs: set[str] = set()
+        broadcast_chats: list[tuple[int, str]] = []
+        for chat_id in chat_ids:
+            try:
+                chat_configs[chat_id] = await database.get_chat_config(chat_id)
+            except ValueError:
+                continue  # chat row missing; _deliver_entry decides cleanup
+            if chat_configs[chat_id].rss_agent_summary:
+                summary_langs.add(lang_by_chat[chat_id])
+            if chat_configs[chat_id].rss_agent_broadcast:
+                broadcast_chats.append((chat_id, lang_by_chat[chat_id]))
+
+        digest_by_lang: dict[str, dict[str, str]] = {}
+        broadcast_by_lang: dict[str, str | None] = {}
+        broadcast_targets: dict[
+            int, str
+        ] = {}  # chat_id -> lang (group, not rate-limited)
+        if app_config.agent and app_config.agent_model:
+            from kmua.plugins.agent.rss_digest import (
+                generate_rss_broadcast,
+                generate_rss_digest,
+            )
+
+            # Never leak a signed feed URL into logs or the model prompt when
+            # the feed has no title (same redaction the fetch path uses).
+            feed_label = result.feed_title or redact_url(feed.url)
+            for lang in summary_langs:
+                digest_by_lang[lang] = await generate_rss_digest(
+                    new_entries, feed_label, lang
+                )
+            # Skip broadcasts while the per-chat rate-limit lock is held:
+            # generating first would burn get_chat + LLM calls every poll.
+            for chat_id, lang in broadcast_chats:
+                if await _broadcast_locked(chat_id):
+                    continue
+                if not await _is_group_chat(chat_id):
+                    continue
+                broadcast_targets[chat_id] = lang
+            for lang in set(broadcast_targets.values()):
+                broadcast_by_lang[lang] = await generate_rss_broadcast(
+                    new_entries, feed_label, lang
+                )
+
+        for chat_id in chat_ids:
             for entry in new_entries:
                 text = rss_service.render_entry(
                     result.feed_title or feed.url, entry, lang_by_chat[chat_id]
                 )
+                chat_config = chat_configs.get(chat_id)
+                if chat_config and chat_config.rss_agent_summary:
+                    digest = digest_by_lang.get(lang_by_chat[chat_id], {}).get(
+                        entry.entry_id
+                    )
+                    if digest:
+                        text = f"💬 {html.escape(digest)}\n\n{text}"
                 if await _deliver_entry(chat_id, text, entry.media_urls):
                     pushed += 1
                 await asyncio.sleep(0.5)
+            if chat_id in broadcast_targets:
+                text = broadcast_by_lang.get(broadcast_targets[chat_id])
+                if text is not None:
+                    await _try_broadcast(chat_id, text)
 
     logger.info(
         f"rss: {len(feeds)} active feed(s), fetched {fetched}, "
@@ -263,3 +325,65 @@ async def _deliver_entry(chat_id: int, text: str, media_urls: list[str]) -> bool
             f"rss: deliver to chat {chat_id} failed: {e.__class__.__name__}: {e}"
         )
         return False
+
+
+async def _is_group_chat(chat_id: int) -> bool:
+    """True when the chat is a supergroup or group (broadcast target only)."""
+    from kmua.bot.client import client
+
+    try:
+        chat = await client.get_chat(chat_id)
+    except Exception as e:
+        logger.warning(
+            f"rss: broadcast chat lookup failed for {chat_id}: "
+            f"{e.__class__.__name__}: {e}"
+        )
+        return False
+    return chat.type in (
+        pyrogram.enums.ChatType.SUPERGROUP,
+        pyrogram.enums.ChatType.GROUP,
+    )
+
+
+async def _broadcast_locked(chat_id: int) -> bool:
+    """True while the per-chat broadcast rate-limit lock is held.
+
+    Read-only peek used before generation so rate-limited chats do not burn
+    LLM calls; the lock itself is only acquired at send time.
+    """
+    return bool(await common.memttlcache.get(f"rss:broadcast:{chat_id}"))
+
+
+async def _broadcast_due(chat_id: int) -> bool:
+    """Rate-limit gate: one broadcast per chat per configured interval.
+
+    Locks via memttlcache; a bot restart resets the lock, which is acceptable
+    (broadcasts are best-effort chatter, not a delivery guarantee).
+    """
+    key = f"rss:broadcast:{chat_id}"
+    if await common.memttlcache.get(key):
+        return False
+    await common.memttlcache.set(
+        key, True, ttl=app_config.rss_agent_broadcast_interval * 60
+    )
+    return True
+
+
+async def _try_broadcast(chat_id: int, text: str | None) -> None:
+    """Send one agent-written broadcast message, rate-limited per chat.
+
+    Sent as plain text (parse_mode=None): the model output is untrusted and
+    must not be interpreted as HTML. Failures are logged and swallowed; a
+    broadcast never cleans up subscriptions or affects the regular push.
+    """
+    if not text or not await _broadcast_due(chat_id):
+        return
+    from kmua.bot.client import client
+
+    try:
+        await client.send_message(chat_id, text, parse_mode=None)
+        logger.debug(f"rss: broadcast sent to {chat_id}")
+    except Exception as e:
+        logger.warning(
+            f"rss: broadcast to chat {chat_id} failed: {e.__class__.__name__}: {e}"
+        )

--- a/kmua/config/__init__.py
+++ b/kmua/config/__init__.py
@@ -310,6 +310,9 @@ class _AppConfig(pydantic.BaseModel):
     rss_whitelist_mode: bool = True
     # Minutes between polls of every active feed.
     rss_interval: int = pydantic.Field(default=30, ge=1, le=1440)
+    # Minimum minutes between agent broadcasts to one chat (per-chat switch:
+    # ChatConfig.rss_agent_broadcast).
+    rss_agent_broadcast_interval: int = pydantic.Field(default=30, ge=1, le=1440)
 
 
 class _InternalConfig(pydantic.BaseModel):

--- a/kmua/database/models.py
+++ b/kmua/database/models.py
@@ -62,6 +62,8 @@ class ChatConfig:
     parse_artwork_enabled: bool = True
     pick_bottle_enabled: bool = True
     group_memory_enabled: bool = True
+    rss_agent_summary: bool = False
+    rss_agent_broadcast: bool = False
     lang: str = "zh-CN"
 
     @classmethod
@@ -85,6 +87,8 @@ class ChatConfig:
             pick_bottle_enabled=data.get("pick_bottle_enabled", True),
             ai_comment=data.get("ai_comment", False),
             group_memory_enabled=data.get("group_memory_enabled", True),
+            rss_agent_summary=data.get("rss_agent_summary", False),
+            rss_agent_broadcast=data.get("rss_agent_broadcast", False),
             lang=data.get("lang", "zh-CN"),
         )
 

--- a/kmua/i18n/locales/en/bot.yml
+++ b/kmua/i18n/locales/en/bot.yml
@@ -192,6 +192,8 @@ bot:
         <code>/rss resume &lt;index&gt;</code> to resume push
         <code>/rss interval &lt;index&gt; &lt;minutes&gt;</code> to set the poll interval; omit minutes to reset to global
         <code>/rss testpush &lt;index&gt;</code> to push this subscription immediately (for testing)
+        <code>/rss digest on|off</code> to enable/disable AI summaries on RSS pushes
+        <code>/rss broadcast on|off</code> to enable/disable AI broadcasts on new entries
       disabled: The RSS subscription feature is disabled.
       not_allowed: "RSS subscriptions are not enabled for this chat (chat_id={chat_id}); ask the owner to allow it in the panel"
       invalid_url: "Invalid URL: it must start with http:// or https://"
@@ -210,6 +212,11 @@ bot:
       interval_invalid: "Interval must be between {min} and {max} minutes"
       too_many_requests: "Too many requests, slow down ({error})"
       testpush_done: "Pushed {count} message(s)"
+      digest_on: AI summaries on RSS pushes enabled.
+      digest_off: AI summaries on RSS pushes disabled.
+      broadcast_on: AI broadcasts on new RSS entries enabled.
+      broadcast_off: AI broadcasts on new RSS entries disabled.
+      toggle_failed: This chat cannot store RSS agent settings right now.
       interval_mark: " · every {minutes} min"
       paused_mark: " (paused)"
       error_mark: " (push error)"

--- a/kmua/i18n/locales/zh-CN/bot.yml
+++ b/kmua/i18n/locales/zh-CN/bot.yml
@@ -174,6 +174,8 @@ bot:
         <code>/rss resume &lt;序号&gt;</code> 恢复推送
         <code>/rss interval &lt;序号&gt; &lt;分钟&gt;</code> 设置抓取间隔, 留空恢复全局
         <code>/rss testpush &lt;序号&gt;</code> 立即推送一次该订阅 (测试用)
+        <code>/rss digest on|off</code> 开启/关闭 RSS 推送 AI 摘要
+        <code>/rss broadcast on|off</code> 开启/关闭 RSS AI 播报
       disabled: RSS 订阅功能未启用
       not_allowed: "RSS 订阅未对此聊天开放"
       invalid_url: URL 无效, 必须以 http:// 或 https:// 开头
@@ -192,6 +194,11 @@ bot:
       interval_invalid: "间隔必须是 {min}-{max} 之间的分钟数"
       too_many_requests: "操作太频繁, 请稍后再试 ({error})"
       testpush_done: "已推送 {count} 条消息"
+      digest_on: 已开启 RSS 推送 AI 摘要
+      digest_off: 已关闭 RSS 推送 AI 摘要
+      broadcast_on: 已开启 RSS AI 播报
+      broadcast_off: 已关闭 RSS AI 播报
+      toggle_failed: 该聊天的配置暂不可用, 无法保存此开关
       interval_mark: " · 每 {minutes} 分钟"
       paused_mark: " (已暂停)"
       error_mark: " (推送错误)"

--- a/kmua/plugins/agent/rss_digest.py
+++ b/kmua/plugins/agent/rss_digest.py
@@ -1,0 +1,189 @@
+"""RSS × Agent: digest summaries and chat broadcasts for pushed feed entries.
+
+Independent of the main agent: importing this module must never build the
+chat agent (``kmua.plugins.agent.agent``), so the RSS poll job can use it even
+when the chat agent is disabled. Both entry points are gated on
+``app_config.agent and app_config.agent_model``; when the gate fails they
+return the "no agent output" values (``{}`` / ``None``) and the caller falls
+back to the raw rendered entry.
+"""
+
+import asyncio
+import json
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic_ai import Agent
+
+from kmua.config import app_config
+from kmua.logger import logger
+from kmua.plugins.agent import provider
+from kmua.services.rss import FeedEntry
+
+_DIGEST_TIMEOUT = 30.0
+"""Hard timeout in seconds for one LLM call; the poll job must never stall."""
+
+
+class RssDigestSummaries(BaseModel):
+    items: dict[str, str]  # entry_id -> 1-2 sentence chat-flavored take
+
+
+_digest_agent: Agent[Any, RssDigestSummaries] | None = None
+_broadcast_agent: Agent[Any, str] | None = None
+
+
+def _make_digest_agent() -> Agent[Any, RssDigestSummaries]:
+    assert app_config.agent_model is not None, "agent_model must be set"
+    return Agent(
+        model=provider.make_chat_model(app_config.agent_model),
+        output_type=RssDigestSummaries,
+        retries=2,
+    )
+
+
+def _make_broadcast_agent() -> Agent[Any, str]:
+    assert app_config.agent_model is not None, "agent_model must be set"
+    return Agent(
+        model=provider.make_chat_model(app_config.agent_model),
+        output_type=str,
+        retries=2,
+    )
+
+
+def build_digest_prompt(
+    entries: list[FeedEntry], feed_title: str, lang: str = "zh-CN"
+) -> str:
+    """Build the prompt for per-entry summaries of one push batch.
+
+    Pure function; the digest agent turns this into ``RssDigestSummaries``.
+    ``lang`` is the chat's delivery locale (e.g. ``zh-CN``), so the take is
+    written in the language the subscribers actually read.
+    """
+    lines = [
+        f"以下是从 RSS feed「{feed_title}」抓取到的一批新条目, 需要你为其中部分条目写群聊口吻的点评:"
+    ]
+    for entry in entries:
+        summary = entry.summary[:300].replace("\n", " ")
+        lines.append(f"\n[{entry.entry_id}]")
+        lines.append(f"标题: {entry.title}")
+        lines.append(f"链接: {entry.link}")
+        if summary:
+            lines.append(f"内容摘要: {summary}")
+    lines.append(
+        f"\n要求: 对每条值得群友关注的条目输出 1-2 句点评, 指出它为什么值得看; "
+        f"不值得提的条目可以省略。点评用 {lang} 语言, 口语化, 不要复述原文。"
+    )
+    return "\n".join(lines)
+
+
+def parse_digest_output(
+    raw: RssDigestSummaries | str | dict, valid_ids: set[str]
+) -> dict[str, str]:
+    """Parse the digest agent's output into an entry_id -> summary map.
+
+    The output arrives as a ``RssDigestSummaries`` instance from the agent, but
+    may also be JSON text or a plain dict in tests. Anything that does not
+    parse, and any entry_id outside ``valid_ids``, is dropped.
+    """
+    if isinstance(raw, RssDigestSummaries):
+        data = raw.items
+    elif isinstance(raw, dict):
+        data = raw
+    elif isinstance(raw, str):
+        try:
+            data = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return {}
+    else:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {
+        str(key): str(value)
+        for key, value in data.items()
+        if str(key) in valid_ids and isinstance(value, str) and value.strip()
+    }
+
+
+def build_broadcast_prompt(
+    entries: list[FeedEntry], feed_title: str, lang: str = "zh-CN"
+) -> str:
+    """Build the prompt for one chat broadcast covering the whole batch.
+
+    Pure function; the broadcast agent returns plain text. ``lang`` is the
+    chat's delivery locale, so the message is written in the group's language.
+    """
+    lines = [f"以下是从 RSS feed「{feed_title}」抓取到的新条目:"]
+    for entry in entries:
+        summary = entry.summary[:300].replace("\n", " ")
+        lines.append(f"\n- 标题: {entry.title}")
+        lines.append(f"  链接: {entry.link}")
+        if summary:
+            lines.append(f"  内容摘要: {summary}")
+    lines.append(
+        f"\n你是一个群聊成员, 刚看到这些新内容。请发一条 1-3 句的群聊消息讨论它们: "
+        f"整体点评这一批内容(不要逐条罗列), 至少包含一个条目的标题和链接, "
+        f"用 {lang} 语言, 口语化, 不用列表符号。"
+    )
+    return "\n".join(lines)
+
+
+async def generate_rss_digest(
+    entries: list[FeedEntry], feed_title: str, lang: str = "zh-CN"
+) -> dict[str, str]:
+    """Summarize one push batch; {} means "no agent output, use raw push"."""
+    global _digest_agent
+    if not entries or not (app_config.agent and app_config.agent_model):
+        return {}
+    try:
+        if _digest_agent is None:
+            _digest_agent = _make_digest_agent()
+        result = await asyncio.wait_for(
+            _digest_agent.run(
+                user_prompt=build_digest_prompt(entries, feed_title, lang),
+            ),
+            timeout=_DIGEST_TIMEOUT,
+        )
+        return parse_digest_output(result.output, {e.entry_id for e in entries})
+    except Exception as e:
+        logger.warning(
+            f"rss_digest: summary generation failed for {feed_title!r}: "
+            f"{e.__class__.__name__}: {e}"
+        )
+        return {}
+
+
+async def generate_rss_broadcast(
+    entries: list[FeedEntry], feed_title: str, lang: str = "zh-CN"
+) -> str | None:
+    """Write one broadcast message for the batch; None means "skip broadcast"."""
+    global _broadcast_agent
+    if not entries or not (app_config.agent and app_config.agent_model):
+        return None
+    try:
+        if _broadcast_agent is None:
+            _broadcast_agent = _make_broadcast_agent()
+        result = await asyncio.wait_for(
+            _broadcast_agent.run(
+                user_prompt=build_broadcast_prompt(entries, feed_title, lang),
+            ),
+            timeout=_DIGEST_TIMEOUT,
+        )
+        text = (result.output or "").strip()
+        return text or None
+    except Exception as e:
+        logger.warning(
+            f"rss_digest: broadcast generation failed for {feed_title!r}: "
+            f"{e.__class__.__name__}: {e}"
+        )
+        return None
+
+
+__all__ = [
+    "RssDigestSummaries",
+    "build_broadcast_prompt",
+    "build_digest_prompt",
+    "generate_rss_broadcast",
+    "generate_rss_digest",
+    "parse_digest_output",
+]

--- a/kmua/plugins/rss.py
+++ b/kmua/plugins/rss.py
@@ -100,6 +100,10 @@ async def rss_command(client: PyrogramClient, message: _T.Message):
             await _rss_manage(message, chat.id, action, lang, command)
         case "interval":
             await _rss_interval(message, chat.id, lang, command)
+        case "digest":
+            await _rss_agent_toggle(message, lang, command, "rss_agent_summary")
+        case "broadcast":
+            await _rss_agent_toggle(message, lang, command, "rss_agent_broadcast")
         case "testpush":
             await _rss_testpush(client, message, chat.id, user.id, lang, command)
         case _:
@@ -285,6 +289,51 @@ async def _rss_interval(
         await message.reply(
             i18n.t("bot.msg.rss.interval_set", locale=lang).format(minutes=minutes)
         )
+
+
+async def _rss_agent_toggle(
+    message: _T.Message, lang: str, command: list[str], field: str
+) -> None:
+    """/rss digest on|off` 与 `/rss broadcast on|off` 的共用实现.
+
+    Reads the current ChatConfig, flips the given field, and writes it back
+    (update_chat_config refreshes the memttlcache, so the change takes effect
+    immediately). The Chat object is passed to get/update so a chat without a
+    ChatData row (e.g. a private chat) is upserted instead of raising.
+    """
+    if message.chat is None:
+        return
+    if len(command) < 3 or command[2].lower() not in ("on", "off"):
+        await message.reply(
+            i18n.t("bot.msg.rss.usage", locale=lang),
+            parse_mode=pyrogram.enums.ParseMode.HTML,
+            reply_markup=_panel_markup(message.chat, lang),
+        )
+        return
+    on = command[2].lower() == "on"
+
+    try:
+        chat_config = await database.get_chat_config(message.chat)
+        if field == "rss_agent_summary":
+            chat_config.rss_agent_summary = on
+            base = "digest"
+        else:
+            chat_config.rss_agent_broadcast = on
+            base = "broadcast"
+        await database.update_chat_config(message.chat, chat_config)
+    except Exception as e:
+        # A chat without a ChatData row (e.g. a private chat) cannot hold a
+        # ChatConfig; fail with a hint instead of crashing the handler.
+        logger.warning(
+            f"rss: toggle {field} failed for chat {message.chat.id}: "
+            f"{e.__class__.__name__}: {e}"
+        )
+        await message.reply(i18n.t("bot.msg.rss.toggle_failed", locale=lang))
+        return
+
+    await message.reply(
+        i18n.t(f"bot.msg.rss.{base}_{'on' if on else 'off'}", locale=lang)
+    )
 
 
 async def _rss_testpush(

--- a/kmua/webapp/routers/chats.py
+++ b/kmua/webapp/routers/chats.py
@@ -104,6 +104,8 @@ async def update_chat_config(
         parse_artwork_enabled=payload.parse_artwork_enabled,
         pick_bottle_enabled=payload.pick_bottle_enabled,
         group_memory_enabled=payload.group_memory_enabled,
+        rss_agent_summary=payload.rss_agent_summary,
+        rss_agent_broadcast=payload.rss_agent_broadcast,
         lang=payload.lang,
     )
 

--- a/kmua/webapp/schemas.py
+++ b/kmua/webapp/schemas.py
@@ -197,6 +197,8 @@ class ChatConfigOut(ApiModel):
     parse_artwork_enabled: bool
     pick_bottle_enabled: bool
     group_memory_enabled: bool
+    rss_agent_summary: bool
+    rss_agent_broadcast: bool
     lang: str
 
 
@@ -216,6 +218,8 @@ class ChatConfigIn(ApiModel):
     parse_artwork_enabled: bool
     pick_bottle_enabled: bool
     group_memory_enabled: bool
+    rss_agent_summary: bool
+    rss_agent_broadcast: bool
     lang: LocaleStr
 
     @field_validator("lang")

--- a/kmua/webapp/serializers.py
+++ b/kmua/webapp/serializers.py
@@ -73,6 +73,8 @@ def chat_config_out(config: ChatConfig) -> ChatConfigOut:
         parse_artwork_enabled=config.parse_artwork_enabled,
         pick_bottle_enabled=config.pick_bottle_enabled,
         group_memory_enabled=config.group_memory_enabled,
+        rss_agent_summary=config.rss_agent_summary,
+        rss_agent_broadcast=config.rss_agent_broadcast,
         lang=config.lang,
     )
 

--- a/tests/test_rss_agent.py
+++ b/tests/test_rss_agent.py
@@ -1,0 +1,368 @@
+"""RSS × Agent: digest summary and broadcast tests.
+
+Covers the pure prompt/parse functions in ``kmua.plugins.agent.rss_digest``,
+the failure fallbacks (agent output must never drop a push), and the
+``jobs.rss_push`` integration with per-chat switches, rate limiting and
+``parse_mode=None`` broadcasts. All model calls are stubbed — no network.
+"""
+
+from __future__ import annotations
+
+import importlib
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from kmua import common, database
+from kmua.bot import jobs
+from kmua.config import app_config
+from kmua.database.models import ChatConfig
+from kmua.plugins.agent import rss_digest
+from kmua.services.rss import FeedEntry, FetchResult
+
+pytestmark = pytest.mark.usefixtures("initialised_db")
+
+CHAT_ID = -100_910_002
+
+
+@pytest.fixture(autouse=True)
+def agent_gate(monkeypatch):
+    """Pass the agent gate so generate_* actually call the (stubbed) agent."""
+    monkeypatch.setattr(app_config, "agent", True, raising=False)
+    monkeypatch.setattr(app_config, "agent_model", "unvapp/kmua", raising=False)
+    # Reset the lazily-built agent singletons between tests so a stubbed agent
+    # from one test is not reused by the next.
+    monkeypatch.setattr(rss_digest, "_digest_agent", None)
+    monkeypatch.setattr(rss_digest, "_broadcast_agent", None)
+
+
+def make_entry(
+    entry_id: str, title: str = "标题", link: str = "https://example.com/x"
+) -> FeedEntry:
+    return FeedEntry(entry_id=entry_id, title=title, link=link, summary="摘要内容")
+
+
+def make_feed() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1,
+        url="https://example.com/feed.xml",
+        etag=None,
+        last_modified=None,
+        # A past fetch time so rss_push reaches the delivery branch (a None
+        # last_fetched_at triggers the first-fetch seed path that pushes nothing).
+        last_fetched_at=datetime.now(UTC) - timedelta(minutes=60),
+        seen_entry_ids=[],
+        failure_count=0,
+    )
+
+
+def make_fetch_result() -> FetchResult:
+    return FetchResult(
+        not_modified=False,
+        feed_title="测试 Feed",
+        etag=None,
+        last_modified=None,
+        entries=[
+            make_entry("e1", title="第一条"),
+            make_entry("e2", title="第二条"),
+        ],
+    )
+
+
+# ---------------------------------------------------------------- pure fns
+
+
+def test_build_digest_prompt_contains_entries_and_title():
+    entries = [make_entry("e1"), make_entry("e2")]
+    prompt = rss_digest.build_digest_prompt(entries, "测试 Feed")
+    assert "[e1]" in prompt and "[e2]" in prompt
+    assert "测试 Feed" in prompt
+    assert "https://example.com/x" in prompt
+
+
+def test_build_digest_prompt_uses_chat_language():
+    prompt = rss_digest.build_digest_prompt([make_entry("e1")], "F", lang="en")
+    assert "用 en 语言" in prompt
+
+
+def test_parse_digest_output_filters_valid_ids():
+    out = rss_digest.parse_digest_output(
+        '{"e1": "点评一", "e2": "点评二", "e3": "点评三"}', {"e1", "e2"}
+    )
+    assert out == {"e1": "点评一", "e2": "点评二"}
+
+
+def test_parse_digest_output_rejects_garbage():
+    assert rss_digest.parse_digest_output("not json", {"e1"}) == {}
+    assert rss_digest.parse_digest_output("", {"e1"}) == {}
+    assert rss_digest.parse_digest_output('["list"]', {"e1"}) == {}
+    assert rss_digest.parse_digest_output('{"e1": 42}', {"e1"}) == {}
+
+
+def test_build_broadcast_prompt_contains_titles_and_links():
+    prompt = rss_digest.build_broadcast_prompt([make_entry("e1")], "测试 Feed")
+    assert "标题" in prompt
+    assert "https://example.com/x" in prompt
+
+
+# --------------------------------------------------------- failure fallback
+
+
+class _FakeAgent:
+    def __init__(self, result):
+        self._result = result
+        self.calls = 0
+
+    async def run(self, **kwargs):
+        self.calls += 1
+        if isinstance(self._result, Exception):
+            raise self._result
+        return SimpleNamespace(output=self._result)
+
+
+@pytest.mark.parametrize("raise_exc", [RuntimeError("boom"), TimeoutError("t/o")])
+async def test_generate_digest_returns_empty_on_failure(monkeypatch, raise_exc):
+    fake = _FakeAgent(raise_exc)
+    monkeypatch.setattr(rss_digest, "_make_digest_agent", lambda: fake)
+    out = await rss_digest.generate_rss_digest([make_entry("e1")], "feed")
+    assert out == {}
+
+
+async def test_generate_digest_parses_agent_output(monkeypatch):
+    fake = _FakeAgent('{"e1": "点评"}')
+    monkeypatch.setattr(rss_digest, "_make_digest_agent", lambda: fake)
+    out = await rss_digest.generate_rss_digest([make_entry("e1")], "feed")
+    assert out == {"e1": "点评"}
+
+
+async def test_generate_broadcast_returns_none_on_failure(monkeypatch):
+    fake = _FakeAgent(RuntimeError("boom"))
+    monkeypatch.setattr(rss_digest, "_make_broadcast_agent", lambda: fake)
+    out = await rss_digest.generate_rss_broadcast([make_entry("e1")], "feed")
+    assert out is None
+
+
+async def test_generate_broadcast_strips_blank_output(monkeypatch):
+    fake = _FakeAgent("   ")
+    monkeypatch.setattr(rss_digest, "_make_broadcast_agent", lambda: fake)
+    out = await rss_digest.generate_rss_broadcast([make_entry("e1")], "feed")
+    assert out is None
+
+
+# ------------------------------------------------------------- jobs wiring
+
+
+@pytest.fixture
+def rss_agent_env(monkeypatch):
+    """Enable agent gating, stub the database and the Telegram client."""
+    monkeypatch.setattr(app_config, "rss_agent_broadcast_interval", 30, raising=False)
+
+    sent: list[tuple[int, str | None, str]] = []  # (chat_id, text, parse_mode)
+
+    async def fake_send_message(chat_id, text, parse_mode=None, **kwargs):
+        sent.append((chat_id, text, parse_mode))
+        return SimpleNamespace(id=1)
+
+    async def fake_get_chat(chat_id):
+        return SimpleNamespace(type=__import__("pyrogram").enums.ChatType.SUPERGROUP)
+
+    fake_client = SimpleNamespace(
+        send_message=fake_send_message, get_chat=fake_get_chat
+    )
+
+    async def fake_chat_lang(chat_id):
+        return "zh-CN"
+
+    monkeypatch.setattr(jobs, "_chat_lang", fake_chat_lang, raising=False)
+
+    async def fake_active_feeds():
+        return [(make_feed(), 30)]
+
+    monkeypatch.setattr(database, "get_active_feeds", fake_active_feeds)
+
+    async def fake_get_feed_target_chats(feed_id):
+        return [CHAT_ID]
+
+    monkeypatch.setattr(database, "get_feed_target_chats", fake_get_feed_target_chats)
+    monkeypatch.setattr(
+        # kmua/bot/__init__.py re-exports the client instance, so the package
+        # attribute "kmua.bot.client" is the Client, not the module; import the
+        # submodule explicitly to patch the real attribute.
+        importlib.import_module("kmua.bot.client"),
+        "client",
+        fake_client,
+        raising=False,
+    )
+
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(database, "record_fetch_success", noop, raising=False)
+    monkeypatch.setattr(database, "touch_fetch", noop, raising=False)
+
+    return sent
+
+
+@pytest.fixture
+def stub_fetch(monkeypatch):
+    async def fake_fetch(url, **kwargs):
+        return make_fetch_result()
+
+    # jobs.rss_push fetches via `kmua.services.rss.fetch_feed` (imported inside
+    # the job), so patching the module attribute covers it.
+    monkeypatch.setattr("kmua.services.rss.fetch_feed", fake_fetch, raising=False)
+
+
+async def test_push_with_summary_prepends_digest(
+    monkeypatch, rss_agent_env, stub_fetch, initialised_db
+):
+    cfg = ChatConfig(rss_agent_summary=True)
+
+    async def fake_get_chat_config(chat_id):
+        return cfg
+
+    monkeypatch.setattr(database, "get_chat_config", fake_get_chat_config)
+
+    async def fake_digest(entries, feed_title, lang):
+        return {"e1": "点评一"}
+
+    monkeypatch.setattr(rss_digest, "generate_rss_digest", fake_digest)
+    await jobs.rss_push()
+
+    sent = rss_agent_env
+    assert sent, "no message was sent"
+    # e1 got the digest prefix; e2 (no digest) still pushed raw.
+    texts = [text for _, text, _ in sent]
+    assert any(text.startswith("💬 点评一") for text in texts)
+    assert any("第二条" in text for text in texts)
+
+
+async def test_push_without_digest_keeps_raw_text(
+    monkeypatch, rss_agent_env, stub_fetch, initialised_db
+):
+    async def fake_get_chat_config(chat_id):
+        return ChatConfig()
+
+    monkeypatch.setattr(database, "get_chat_config", fake_get_chat_config)
+    await jobs.rss_push()
+
+    texts = [text for _, text, _ in rss_agent_env]
+    assert texts and all(not text.startswith("💬") for text in texts)
+    assert any("第一条" in text for text in texts)
+
+
+async def test_broadcast_sent_with_plain_text_and_rate_limited(
+    monkeypatch, rss_agent_env, stub_fetch, initialised_db
+):
+    await common.memttlcache.delete(f"rss:broadcast:{CHAT_ID}")
+    cfg = ChatConfig(rss_agent_broadcast=True)
+
+    async def fake_get_chat_config(chat_id):
+        return cfg
+
+    monkeypatch.setattr(database, "get_chat_config", fake_get_chat_config)
+
+    calls = []
+
+    async def fake_broadcast(entries, feed_title, lang):
+        calls.append(lang)
+        return "播报文本"
+
+    monkeypatch.setattr(rss_digest, "generate_rss_broadcast", fake_broadcast)
+
+    await jobs.rss_push()
+    broadcasts = [
+        (chat_id, text, mode)
+        for chat_id, text, mode in rss_agent_env
+        if text == "播报文本"
+    ]
+    assert len(broadcasts) == 1
+    chat_id, text, mode = broadcasts[0]
+    assert chat_id == CHAT_ID
+    assert mode is None  # parse_mode=None, plain text
+
+    # Second poll: the rate-limit lock is held, so generation is skipped
+    # entirely (no extra LLM call) and nothing new is broadcast.
+    await jobs.rss_push()
+    assert len(calls) == 1
+    broadcasts = [
+        (chat_id, text, mode)
+        for chat_id, text, mode in rss_agent_env
+        if text == "播报文本"
+    ]
+    assert len(broadcasts) == 1
+
+
+async def test_all_switches_off_matches_plain_push(
+    monkeypatch, rss_agent_env, stub_fetch, initialised_db
+):
+    async def fake_get_chat_config(chat_id):
+        return ChatConfig()
+
+    monkeypatch.setattr(database, "get_chat_config", fake_get_chat_config)
+    await jobs.rss_push()
+    texts = [text for _, text, _ in rss_agent_env]
+    assert len(texts) == 2  # two entries, no extra broadcast
+
+
+async def test_rss_agent_toggle_requires_chat_row(
+    initialised_db,
+):
+    """A private chat has no ChatData row: the toggle must reply a hint,
+    not crash, and the switch must not be persisted anywhere."""
+    import pyrogram
+
+    from kmua.plugins.rss import _rss_agent_toggle
+
+    chat_id = 9_000_123
+    chat = pyrogram.types.Chat(
+        id=chat_id, type=pyrogram.enums.ChatType.PRIVATE, title=None
+    )
+    replies: list[str] = []
+
+    async def reply(text, **kwargs):
+        replies.append(text)
+
+    message = SimpleNamespace(chat=chat, reply=reply)
+    await _rss_agent_toggle(
+        message, "zh-CN", ["rss", "digest", "on"], "rss_agent_summary"
+    )
+
+    assert replies and "无法保存" in replies[0]
+
+
+async def test_rss_agent_toggle_persists_for_group_chat(
+    initialised_db,
+):
+    """A group chat with a ChatData row toggles on and off and persists."""
+    import pyrogram
+
+    from kmua.plugins.rss import _rss_agent_toggle
+
+    chat_id = -100_9_000_123
+    chat = pyrogram.types.Chat(
+        id=chat_id, type=pyrogram.enums.ChatType.SUPERGROUP, title="测试群"
+    )
+    replies: list[str] = []
+
+    async def reply(text, **kwargs):
+        replies.append(text)
+
+    message = SimpleNamespace(chat=chat, reply=reply)
+    await _rss_agent_toggle(
+        message, "zh-CN", ["rss", "digest", "on"], "rss_agent_summary"
+    )
+
+    cfg = await database.get_chat_config(chat_id)
+    assert cfg.rss_agent_summary is True
+    assert cfg.rss_agent_broadcast is False
+    assert replies and "已开启" in replies[0]
+
+    # Toggling back off persists too.
+    await _rss_agent_toggle(
+        message, "zh-CN", ["rss", "digest", "off"], "rss_agent_summary"
+    )
+    cfg = await database.get_chat_config(chat_id)
+    assert cfg.rss_agent_summary is False
+    assert replies[-1] and "已关闭" in replies[-1]

--- a/tests/test_webapp_chat_config.py
+++ b/tests/test_webapp_chat_config.py
@@ -44,6 +44,8 @@ def valid_config(**overrides) -> dict:
         "parse_artwork_enabled": True,
         "pick_bottle_enabled": True,
         "group_memory_enabled": True,
+        "rss_agent_summary": False,
+        "rss_agent_broadcast": False,
         "lang": "zh-CN",
     }
     payload.update(overrides)

--- a/webapp/src/api/types.ts
+++ b/webapp/src/api/types.ts
@@ -125,6 +125,8 @@ export interface ChatConfig {
   parse_artwork_enabled: boolean;
   pick_bottle_enabled: boolean;
   group_memory_enabled: boolean;
+  rss_agent_summary: boolean;
+  rss_agent_broadcast: boolean;
   lang: string;
 }
 

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -150,7 +150,9 @@
     "parse_artwork_enabled": "Parse artwork links",
     "pick_bottle_enabled": "Pick drift bottles",
     "group_memory_enabled": "Group memory",
-    "group_memory_enabledHint": "Let kmua remember this group's conversations"
+    "group_memory_enabledHint": "Let kmua remember this group's conversations",
+    "rss_agent_summary": "AI summary on RSS pushes",
+    "rss_agent_broadcast": "AI broadcast on new RSS entries"
   },
   "titlePermissions": {
     "can_change_info": "Change group info",

--- a/webapp/src/i18n/zh-CN.json
+++ b/webapp/src/i18n/zh-CN.json
@@ -150,7 +150,9 @@
     "parse_artwork_enabled": "解析插画链接",
     "pick_bottle_enabled": "捡漂流瓶",
     "group_memory_enabled": "群组记忆",
-    "group_memory_enabledHint": "让 kmua 记住这个群的对话内容"
+    "group_memory_enabledHint": "让 kmua 记住这个群的对话内容",
+    "rss_agent_summary": "RSS 推送 AI 摘要",
+    "rss_agent_broadcast": "RSS AI 播报"
   },
   "titlePermissions": {
     "can_change_info": "修改群信息",

--- a/webapp/src/views/chats/ChatConfigView.vue
+++ b/webapp/src/views/chats/ChatConfigView.vue
@@ -56,6 +56,8 @@ const EMPTY_CONFIG: ChatConfigInput = {
   parse_artwork_enabled: true,
   pick_bottle_enabled: true,
   group_memory_enabled: true,
+  rss_agent_summary: false,
+  rss_agent_broadcast: false,
   lang: "zh-CN",
 };
 

--- a/webapp/src/views/chats/config-layout.ts
+++ b/webapp/src/views/chats/config-layout.ts
@@ -30,7 +30,14 @@ export const TOGGLE_GROUPS: ToggleGroup[] = [
   },
   {
     labelKey: "ai",
-    keys: ["ai_reply", "ai_reply_other_bots_enabled", "ai_comment", "group_memory_enabled"],
+    keys: [
+      "ai_reply",
+      "ai_reply_other_bots_enabled",
+      "ai_comment",
+      "group_memory_enabled",
+      "rss_agent_summary",
+      "rss_agent_broadcast",
+    ],
   },
   {
     labelKey: "content",


### PR DESCRIPTION
Added ChatConfig switches rss_agent_summary and rss_agent_broadcast (default off). Added rss_digest module generating per-entry digests and broadcasts via the main model. Wired rss_push to prepend digests and send rate-limited broadcasts for enabled group chats. Exposed the switches in the webapp chat config page and via /rss digest|broadcast. Broadcast generation is skipped while the per-chat rate-limit lock is held.