### PR TITLE
feat(wechat): parsed WeChat articles into rich messages

### DIFF
--- a/kmua/database/models.py
+++ b/kmua/database/models.py
@@ -62,6 +62,7 @@ class ChatConfig:
     parse_artwork_enabled: bool = True
     pick_bottle_enabled: bool = True
     group_memory_enabled: bool = True
+    parse_wechat_enabled: bool = True
     rss_agent_summary: bool = False
     rss_agent_broadcast: bool = False
     lang: str = "zh-CN"
@@ -87,6 +88,7 @@ class ChatConfig:
             pick_bottle_enabled=data.get("pick_bottle_enabled", True),
             ai_comment=data.get("ai_comment", False),
             group_memory_enabled=data.get("group_memory_enabled", True),
+            parse_wechat_enabled=data.get("parse_wechat_enabled", True),
             rss_agent_summary=data.get("rss_agent_summary", False),
             rss_agent_broadcast=data.get("rss_agent_broadcast", False),
             lang=data.get("lang", "zh-CN"),

--- a/kmua/i18n/locales/en/bot.yml
+++ b/kmua/i18n/locales/en/bot.yml
@@ -221,6 +221,8 @@ bot:
       paused_mark: " (paused)"
       error_mark: " (push error)"
       untitled: Untitled
+    wechat:
+      read_original: Read original
     waifu:
       disabled: The waifu feature is not allowed here.
       not_found: You don't have a waifu right now because I can't find any other members in my records.

--- a/kmua/i18n/locales/zh-CN/bot.yml
+++ b/kmua/i18n/locales/zh-CN/bot.yml
@@ -203,3 +203,5 @@ bot:
       paused_mark: " (已暂停)"
       error_mark: " (推送错误)"
       untitled: 无标题
+    wechat:
+      read_original: 阅读原文

--- a/kmua/plugins/agent/agent.py
+++ b/kmua/plugins/agent/agent.py
@@ -680,6 +680,8 @@ _filter = (
     & (myfilter.reply_me_filter | filters.private | myfilter.mention_me_filter)
     & myfilter.not_bottle_reply_filter
     & ~pyrogram.filters.regex("|".join([r.pattern for r in manyacg.ARTWORK_ALL_REGEX]))
+    # WeChat article links are handled by the wechat parser (group -1).
+    & ~pyrogram.filters.regex(r"https?://mp\.weixin\.qq\.com/s/[A-Za-z0-9_-]+")
 )
 
 _chat_command_filter = (

--- a/kmua/plugins/simple_reply.py
+++ b/kmua/plugins/simple_reply.py
@@ -138,6 +138,9 @@ _filter = (
     & (_reply_me_filter | filters.private | _mention_me_filter)
     & _not_bottle_reply_filter
     & ~pyrogram.filters.regex("|".join([r.pattern for r in manyacg.ARTWORK_ALL_REGEX]))
+    # WeChat article links are handled by the wechat parser (group -1); the
+    # keyword reply must not double-respond to them.
+    & ~pyrogram.filters.regex(r"https?://mp\.weixin\.qq\.com/s/[A-Za-z0-9_-]+")
 )
 
 _chat_command_filter = filters.command("chat") & _not_bottle_reply_filter

--- a/kmua/plugins/wechat.py
+++ b/kmua/plugins/wechat.py
@@ -1,0 +1,262 @@
+"""WeChat article parsing: detect mp.weixin.qq.com links and re-send the
+article as a rich Telegram message (media group when the article has images,
+formatted text otherwise).
+
+Follows the parse_artwork pattern: a regex filter on group 0, gated per chat
+by ChatConfig.parse_wechat_enabled.
+"""
+
+import io
+from typing import Any
+
+import httpx
+import pyrogram
+from pyrogram.client import Client as PyrogramClient
+
+# kurigram's raw messages.SendMessage is not re-exported from the package
+# namespace, so import it from its module file directly.
+from pyrogram.raw.functions.messages.send_message import (
+    SendMessage as _RawSendMessage,
+)
+from pyrogram.raw.functions.messages.upload_media import (
+    UploadMedia as _RawUploadMedia,
+)
+from pyrogram.raw.types.input_media_uploaded_photo import (
+    InputMediaUploadedPhoto as _RawInputMediaUploadedPhoto,
+)
+from pyrogram.raw.types.input_photo import InputPhoto as _RawInputPhoto
+from pyrogram.raw.types.input_rich_message import (
+    InputRichMessage as _RawInputRichMessage,
+)
+
+from kmua import database
+from kmua.logger import logger
+from kmua.services import wechat as wechat_service
+from kmua.services.wechat import WECHAT_URL_RE
+
+_DOWNLOAD_TIMEOUT = httpx.Timeout(60.0, connect=10.0)
+
+
+# group -1: run before the group-0 handlers (keyword replies, wake_agent),
+# which own group 0 and break after the first filter match.
+@PyrogramClient.on_message(pyrogram.filters.regex(WECHAT_URL_RE.pattern), group=-1)
+async def parse_wechat_article(client: PyrogramClient, message: pyrogram.types.Message):
+    chat = message.chat
+    user = message.from_user or message.sender_chat
+    if not user or not user.id or not chat or not chat.id:
+        return
+    if chat.type in (pyrogram.enums.ChatType.SUPERGROUP, pyrogram.enums.ChatType.GROUP):
+        chat_config = await database.get_chat_config(chat.id)
+        if not chat_config.parse_wechat_enabled:
+            return
+        lang = chat_config.lang
+    else:
+        user_config = await database.get_user_config(user.id)
+        lang = user_config.lang
+    assert chat.id is not None
+    if not message.matches or not message.text:
+        return
+    article_url = message.matches[0].group()
+    if not article_url:
+        return
+    if not article_url.startswith("http"):
+        article_url = "https://" + article_url
+    if not wechat_service.is_wechat_url(article_url):
+        return
+
+    await message.reply_chat_action(pyrogram.enums.ChatAction.TYPING)
+    try:
+        article = await wechat_service.fetch_article(article_url)
+    except Exception as e:
+        logger.error(
+            f"wechat: fetch failed for {article_url}: {e.__class__.__name__}: {e}"
+        )
+        return
+    if not article.title and not article.paragraphs:
+        return
+
+    try:
+        # One rich message: structured blocks (heading, block-quoted body,
+        # images at their original document positions) with the images
+        # uploaded first and referenced as InputPhoto ids — the native
+        # MTProto equivalent of Bot API 10.2 media support.
+        photo_ids = await _upload_rich_photos(client, chat.id, article)
+        await _send_rich_reply(
+            client,
+            chat.id,
+            wechat_service.build_rich_blocks(article, lang, photo_ids),
+            photo_ids,
+            message.id,
+        )
+    except Exception as e:
+        logger.warning(
+            f"wechat: rich send failed for {article.url}: {e.__class__.__name__}: {e}"
+        )
+        try:
+            if article.images:
+                await _send_media_group(client, message, article, lang)
+            else:
+                raise
+        except Exception as e2:
+            logger.error(f"wechat: send failed: {e2.__class__.__name__}: {e2}")
+
+
+async def _send_rich_reply(
+    client: PyrogramClient,
+    chat_id: int,
+    blocks: list[Any],
+    photos: list[Any],
+    reply_to_message_id: int,
+) -> None:
+    """Send one rich message replying to the source message.
+
+    Uses raw ``messages.SendMessage`` directly instead of
+    ``client.send_rich_message``: that helper's response parsing is broken in
+    kurigram 2.2.24 (it indexes ``peer.chat_id`` on an ``InputPeerChannel``,
+    raising AttributeError for any group/channel send). Invoking the raw
+    function and ignoring the response avoids the bug entirely. ``blocks`` is
+    a raw PageBlock list and ``photos`` the InputPhoto list they reference.
+    """
+    peer = await client.resolve_peer(chat_id)
+    assert peer is not None
+    await client.invoke(
+        _RawSendMessage(
+            peer=peer,
+            message="",
+            random_id=client.rnd_id(),
+            reply_to=await pyrogram.utils.get_reply_to(  # type: ignore
+                client,
+                pyrogram.types.ReplyParameters(message_id=reply_to_message_id),
+                None,
+                None,
+            ),
+            rich_message=_RawInputRichMessage(
+                blocks=blocks,
+                photos=[p for p in photos if p is not None] or None,
+            ),
+        ),
+    )
+
+
+async def _upload_rich_photos(
+    client: PyrogramClient,
+    chat_id: int,
+    article: wechat_service.WechatArticle,
+) -> list[Any]:
+    """Upload the article's images, returning InputPhoto objects in
+    image-block order (None where a photo failed to download/validate/upload,
+    so the rich builder drops that image).
+    """
+    image_urls = [block.content for block in article.blocks if block.kind == "image"]
+    if not image_urls:
+        return []
+    peer = await client.resolve_peer(chat_id)
+    assert peer is not None
+    photos: list[Any] = []
+    async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT) as http_client:
+        for idx, image_url in enumerate(image_urls):
+            try:
+                data = await wechat_service.download_image(http_client, image_url)
+                uploaded = await client.save_file(io.BytesIO(data))
+                assert uploaded is not None
+                media = await client.invoke(
+                    _RawUploadMedia(
+                        peer=peer,
+                        media=_RawInputMediaUploadedPhoto(file=uploaded),
+                    )
+                )
+                photo = getattr(media, "photo", None)
+                if photo is None or not getattr(photo, "id", None):
+                    raise ValueError("upload returned no photo")
+                photos.append(
+                    _RawInputPhoto(
+                        id=photo.id,
+                        access_hash=photo.access_hash,
+                        file_reference=photo.file_reference,
+                    )
+                )
+            except Exception as e:
+                logger.warning(
+                    f"wechat: rich photo {idx} upload failed for {article.url}: "
+                    f"{e.__class__.__name__}: {e}"
+                )
+                photos.append(None)
+    return photos
+
+
+async def _send_media_group(
+    client: PyrogramClient,
+    message: pyrogram.types.Message,
+    article: wechat_service.WechatArticle,
+    lang: str,
+) -> bool:
+    """Download up to 10 images and send them as a media group.
+
+    The caption (title/author/excerpt/link) is shown above the media using
+    show_caption_above_media. Failed downloads are skipped; the rest still go
+    out. Returns True when the group was sent; on total failure a rich text
+    fallback is sent and False is returned.
+    """
+    caption = wechat_service.build_media_caption(article, lang)
+    chat = message.chat
+    assert chat is not None and chat.id is not None
+    inputs: list[
+        pyrogram.types.InputMediaPhoto
+        | pyrogram.types.InputMediaVideo
+        | pyrogram.types.InputMediaAudio
+        | pyrogram.types.InputMediaDocument
+    ] = []
+    async with httpx.AsyncClient(timeout=_DOWNLOAD_TIMEOUT) as http_client:
+        for idx, image_url in enumerate(article.images[:10]):
+            try:
+                data = await wechat_service.download_image(http_client, image_url)
+            except Exception as e:
+                logger.warning(
+                    f"wechat: image {idx} download failed for {article.url}: "
+                    f"{e.__class__.__name__}: {e}"
+                )
+                continue
+            inputs.append(
+                pyrogram.types.InputMediaPhoto(
+                    media=io.BytesIO(data),
+                    caption=caption if idx == 0 else "",
+                    parse_mode=pyrogram.enums.ParseMode.HTML,
+                )
+            )
+    if not inputs:
+        # All downloads failed: fall back to a rich text message.
+        await _send_rich_reply(
+            client,
+            chat.id,
+            wechat_service.build_rich_blocks(article, lang),
+            [],
+            message.id,
+        )
+        return False
+    try:
+        await client.send_media_group(
+            chat.id,
+            inputs,
+            reply_parameters=pyrogram.types.ReplyParameters(message_id=message.id),
+            # Telegram's caption-above-media layout for the media group.
+            show_caption_above_media=True,
+        )
+        return True
+    except Exception as e:
+        # Telegram rejected the media group (e.g. PhotoInvalidDimensions):
+        # still deliver the article as a rich text message.
+        logger.warning(
+            f"wechat: media group rejected for {article.url}: "
+            f"{e.__class__.__name__}: {e}"
+        )
+        await _send_rich_reply(
+            client,
+            chat.id,
+            wechat_service.build_rich_blocks(article, lang),
+            [],
+            message.id,
+        )
+        return False
+
+
+__all__ = ["parse_wechat_article"]

--- a/kmua/services/wechat.py
+++ b/kmua/services/wechat.py
@@ -1,0 +1,475 @@
+"""WeChat (Weixin) official-account article parsing.
+
+Fetches mp.weixin.qq.com article pages and extracts the title, author, body
+text and image URLs. Pure functions are separated from network I/O so the
+parsing logic is unit-testable without touching the network.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import html as html_mod
+import io
+import re
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+from lxml import html as lxml_html
+from PIL import Image
+
+_WECHAT_HOST = "mp.weixin.qq.com"
+_IMAGE_HOSTS = ("mmbiz.qpic.cn", "mmbiz.wxpic.cn")
+_TIMEOUT = httpx.Timeout(20.0, connect=10.0)
+_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0 Safari/537.36"
+)
+
+# Article short links: https://mp.weixin.qq.com/s/<id>
+WECHAT_URL_RE = re.compile(r"https?://mp\.weixin\.qq\.com/s/[A-Za-z0-9_-]+")
+
+_MAX_BODY_CHARS = 3500
+_MAX_PARAGRAPH_CHARS = 500
+_MAX_IMAGES = 10
+
+
+@dataclass(slots=True)
+class WechatBlock:
+    """One body item in document order: a text paragraph or an image URL."""
+
+    kind: str  # "text" | "image"
+    content: str
+
+
+@dataclass(slots=True)
+class WechatArticle:
+    url: str
+    title: str = ""
+    author: str | None = None
+    published_at: datetime | None = None
+    paragraphs: list[str] = field(default_factory=list)
+    images: list[str] = field(default_factory=list)
+    blocks: list[WechatBlock] = field(default_factory=list)
+    description: str = ""
+
+
+def is_wechat_url(url: str) -> bool:
+    """True for a https://mp.weixin.qq.com/s/<id> link (host-exact, no userinfo)."""
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return False
+    return (
+        parts.scheme == "https"
+        and parts.netloc == _WECHAT_HOST
+        and bool(re.fullmatch(r"[A-Za-z0-9_-]+", parts.path.removeprefix("/s/")))
+        and parts.path.startswith("/s/")
+    )
+
+
+def _is_wechat_image_url(url: str) -> bool:
+    try:
+        parts = urlsplit(url)
+    except ValueError:
+        return False
+    return (
+        parts.scheme in ("http", "https")
+        and parts.hostname is not None
+        and (
+            parts.hostname == _IMAGE_HOSTS[0]
+            or parts.hostname.endswith("." + _IMAGE_HOSTS[0])
+        )
+        or (
+            parts.hostname == _IMAGE_HOSTS[1]
+            or (parts.hostname or "").endswith("." + _IMAGE_HOSTS[1])
+        )
+    )
+
+
+def _meta_content(doc: Any, prop: str) -> str | None:
+    nodes = doc.xpath(f'//meta[@property="{prop}"]/@content')
+    if nodes:
+        return nodes[0].strip()
+    return None
+
+
+def _normalize_newlines(text: str) -> str:
+    """Convert WeChat's literal ``\\x0a`` / ``\\n`` escapes to real newlines
+    and drop zero-width characters (ZWNJ etc.) that WeChat sprinkles between
+    paragraphs; they render as phantom blank lines inside block quotes.
+    """
+    text = re.sub(r"\\x0a", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"\\n", "\n", text)
+    return re.sub(r"[\u200b-\u200f\ufeff]", "", text)
+
+
+def _paragraphs_from_html(raw_html: str) -> list[str]:
+    """Body text from the #js_content node, split into non-empty paragraphs.
+
+    WeChat embeds literal ``\\x0a`` (and ``\\n``) escape sequences in the
+    HTML to represent line breaks; those are converted to real newlines
+    before splitting.
+    """
+    doc = lxml_html.fromstring(raw_html)
+    node = doc.xpath('//*[@id="js_content"]')
+    if not node:
+        return []
+    text = _normalize_newlines(node[0].text_content())
+    paragraphs = []
+    for para in re.split(r"\n+", text):
+        para = re.sub(r"[ \t\r\u00a0]+", " ", para).strip()
+        if para:
+            paragraphs.append(para)
+    return paragraphs
+
+
+def _images_from_html(raw_html: str) -> list[str]:
+    """Image URLs from #js_content <img> tags (data-src first, then src)."""
+    doc = lxml_html.fromstring(raw_html)
+    node = doc.xpath('//*[@id="js_content"]')
+    if not node:
+        return []
+    urls: list[str] = []
+    for img in node[0].xpath(".//img"):
+        url = img.get("data-src") or img.get("src") or ""
+        if _is_wechat_image_url(url):
+            urls.append(url)
+    return urls[:_MAX_IMAGES]
+
+
+def _blocks_from_html(raw_html: str) -> list[WechatBlock]:
+    """Body items in document order: paragraphs interleaved with images.
+
+    Walks the #js_content tree keeping text and <img> order, so the rich
+    message can interleave images into the body exactly where WeChat put them.
+    """
+    doc = lxml_html.fromstring(raw_html)
+    node = doc.xpath('//*[@id="js_content"]')
+    if not node:
+        return []
+    root = node[0]
+    blocks: list[WechatBlock] = []
+
+    def walk(el: Any) -> None:
+        # Text before this element's children.
+        if el.text and el.text.strip():
+            blocks.append(WechatBlock(kind="text", content=el.text))
+        for child in el:
+            if isinstance(child.tag, str):
+                if child.tag.lower() == "img":
+                    url = child.get("data-src") or child.get("src") or ""
+                    if _is_wechat_image_url(url):
+                        blocks.append(WechatBlock(kind="image", content=url))
+                else:
+                    walk(child)
+            if child.tail and child.tail.strip():
+                blocks.append(WechatBlock(kind="text", content=child.tail))
+
+    walk(root)
+
+    # Merge adjacent text blocks, then normalize into paragraphs.
+    merged: list[WechatBlock] = []
+    for block in blocks:
+        if block.kind == "text":
+            text = _normalize_newlines(block.content)
+            text = re.sub(r"[ \t\r\u00a0]+", " ", text).strip()
+            if not text:
+                continue
+            if merged and merged[-1].kind == "text":
+                merged[-1].content += "\n" + text
+            else:
+                merged.append(WechatBlock(kind="text", content=text))
+        else:
+            merged.append(block)
+
+    # Split multi-paragraph text blocks, keeping image positions.
+    result: list[WechatBlock] = []
+    image_count = 0
+    for block in merged:
+        if block.kind == "image":
+            if image_count < _MAX_IMAGES:
+                image_count += 1
+                result.append(block)
+            continue
+        for para in re.split(r"\n+", block.content):
+            para = para.strip()
+            if para:
+                result.append(WechatBlock(kind="text", content=para))
+    return result
+
+
+def parse_article_html(raw_html: str, url: str) -> WechatArticle:
+    """Extract title, author, body paragraphs and images from an article page.
+
+    Pure function. When the page carries no body (WeChat's share-card/verify
+    pages), ``paragraphs`` falls back to the og:description so the message is
+    still informative.
+    """
+    doc = lxml_html.fromstring(raw_html)
+
+    title = _meta_content(doc, "og:title") or ""
+    author_nodes = doc.xpath('//*[@id="js_name"]/text()')
+    author = (author_nodes[0].strip() if author_nodes else None) or None
+    if not author:
+        author = _meta_content(doc, "og:article:author") or None
+    description = _meta_content(doc, "og:description") or ""
+
+    published_at: datetime | None = None
+    time_nodes = doc.xpath('//*[@id="publish_time"]/text()')
+    if time_nodes and (t := time_nodes[0].strip()):
+        try:
+            published_at = datetime.strptime(t, "%Y-%m-%d %H:%M")
+        except ValueError:
+            published_at = None
+    if published_at is None:
+        ct_match = re.search(r"var ct = \"?(\d{10})\"?", raw_html)
+        if ct_match:
+            try:
+                published_at = datetime.fromtimestamp(int(ct_match.group(1)))
+            except (ValueError, OSError):
+                published_at = None
+
+    paragraphs = _paragraphs_from_html(raw_html)
+    images = _images_from_html(raw_html)
+    blocks = _blocks_from_html(raw_html)
+    if not paragraphs and description:
+        paragraphs = [_normalize_newlines(description)]
+    if not blocks and paragraphs:
+        blocks = [WechatBlock(kind="text", content=p) for p in paragraphs]
+    return WechatArticle(
+        url=url,
+        title=title.strip(),
+        author=author,
+        published_at=published_at,
+        paragraphs=paragraphs,
+        images=images,
+        blocks=blocks,
+        description=description,
+    )
+
+
+async def fetch_article(url: str) -> WechatArticle:
+    """Fetch and parse one article. Raises on network/parse failure."""
+    if not is_wechat_url(url):
+        raise ValueError(f"not a wechat article url: {url!r}")
+    async with httpx.AsyncClient(
+        timeout=_TIMEOUT,
+        headers={"User-Agent": _USER_AGENT, "Accept-Language": "zh-CN,zh;q=0.9"},
+        follow_redirects=True,
+    ) as client:
+        resp = await client.get(url)
+        resp.raise_for_status()
+        return parse_article_html(resp.text, str(resp.url))
+
+
+def _truncate(text: str, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def build_rich_blocks(
+    article: WechatArticle,
+    lang: str = "zh-CN",
+    photo_refs: list[Any] | None = None,
+) -> list[Any]:
+    """Build structured MTProto rich-message blocks (raw PageBlock list).
+
+    Images are referenced by uploaded photo id (``PageBlockPhoto.photo_id``
+    matches an ``InputPhoto`` passed in ``InputRichMessage.photos``), which is
+    the native MTProto equivalent of Bot API 10.2 media support — no URL
+    fetching involved. ``photo_refs`` maps the article's image blocks in
+    order to uploaded ``InputPhoto`` objects; ``None`` drops the image.
+    """
+    # kurigram does not re-export the new rich-message raw types from the
+    # package namespace; import each from its generated module file.
+    from pyrogram.raw.types.page_block_blockquote import (
+        PageBlockBlockquote as _RBlockquote,
+    )
+    from pyrogram.raw.types.page_block_divider import PageBlockDivider as _RDivider
+    from pyrogram.raw.types.page_block_heading1 import (
+        PageBlockHeading1 as _RHeading1,
+    )
+    from pyrogram.raw.types.page_block_paragraph import (
+        PageBlockParagraph as _RParagraph,
+    )
+    from pyrogram.raw.types.page_block_photo import PageBlockPhoto as _RPhoto
+    from pyrogram.raw.types.page_caption import PageCaption as _RCaption
+    from pyrogram.raw.types.text_empty import TextEmpty as _REmpty
+    from pyrogram.raw.types.text_plain import TextPlain as _RPlain
+    from pyrogram.raw.types.text_url import TextUrl as _RUrl
+
+    from kmua import i18n
+
+    def text(value: str) -> Any:
+        return _RPlain(text=value)
+
+    blocks: list[Any] = []
+    if article.title:
+        blocks.append(_RHeading1(text=text(article.title)))
+    meta: list[str] = []
+    if article.author:
+        meta.append(article.author)
+    if article.published_at:
+        meta.append(article.published_at.strftime("%Y-%m-%d"))
+    if meta:
+        blocks.append(_RParagraph(text=text("👤 " + " · ".join(meta))))
+    blocks.append(_RDivider())
+
+    body = article.blocks or [
+        WechatBlock(kind="text", content=p) for p in article.paragraphs
+    ]
+    image_index = 0
+    remaining = _MAX_BODY_CHARS
+    quote_buffer: list[str] = []
+
+    def flush_quote() -> None:
+        # Consecutive paragraphs share ONE block quote (separated by blank
+        # lines inside it) instead of one block per paragraph, so the body
+        # reads as a continuous quotation.
+        if not quote_buffer:
+            return
+        blocks.append(
+            _RBlockquote(
+                text=text("\n\n".join(quote_buffer)),
+                caption=_REmpty(),
+            )
+        )
+        quote_buffer.clear()
+
+    for block in body:
+        if block.kind == "image":
+            ref = (
+                photo_refs[image_index]
+                if photo_refs and image_index < len(photo_refs)
+                else None
+            )
+            image_index += 1
+            flush_quote()
+            if ref is None:
+                continue
+            blocks.append(
+                _RPhoto(
+                    photo_id=ref.id,
+                    caption=_RCaption(text=_REmpty(), credit=_REmpty()),
+                )
+            )
+            continue
+        if remaining <= 0:
+            break
+        chunk = _truncate(block.content, min(_MAX_PARAGRAPH_CHARS, remaining))
+        # Normalize inner newlines: a single paragraph may carry several
+        # line breaks from the source HTML; collapse runs so the joined
+        # quote shows one blank line between paragraphs, not a wall of them.
+        chunk = re.sub(r"\n+", "\n", chunk).strip()
+        quote_buffer.append(chunk)
+        remaining -= len(chunk)
+    flush_quote()
+
+    blocks.append(_RDivider())
+    blocks.append(
+        _RParagraph(
+            text=_RUrl(
+                url=article.url,
+                webpage_id=0,
+                text=text(i18n.t("bot.msg.wechat.read_original", locale=lang)),
+            )
+        )
+    )
+    return blocks
+
+
+def build_media_caption(article: WechatArticle, lang: str = "zh-CN") -> str:
+    """Short caption for a media group (shown above the images).
+
+    Pure function; Telegram's caption limit is 1024 characters.
+    """
+    from kmua import i18n
+
+    lines: list[str] = []
+    if article.title:
+        lines.append(f"<b>{html_mod.escape(article.title)}</b>")
+    meta: list[str] = []
+    if article.author:
+        meta.append(html_mod.escape(article.author))
+    if article.published_at:
+        meta.append(html_mod.escape(article.published_at.strftime("%Y-%m-%d")))
+    if meta:
+        lines.append("👤 " + " · ".join(meta))
+    if article.paragraphs:
+        excerpt = _truncate(article.paragraphs[0], 200)
+        lines.append(f"<blockquote>{html_mod.escape(excerpt)}</blockquote>")
+    lines.append(
+        f'🔗 <a href="{html_mod.escape(article.url)}">'
+        f"{html_mod.escape(i18n.t('bot.msg.wechat.read_original', locale=lang))}</a>"
+    )
+    caption = "\n".join(lines)
+    return _truncate(caption, 1024)
+
+
+def _resize_image(pic_bytes: bytes) -> bytes:
+    """Shrink an oversized image to 2560px max, JPEG q90 (Telegram limit)."""
+    with Image.open(io.BytesIO(pic_bytes)) as image:
+        ratio = 2560 / max(image.width, image.height)
+        if ratio < 1:
+            image = image.resize(
+                (int(image.width * ratio), int(image.height * ratio)),
+                Image.Resampling.LANCZOS,
+            )
+        output = io.BytesIO()
+        image.convert("RGB").save(output, format="JPEG", quality=90)
+        return output.getvalue()
+
+
+def _validate_image(data: bytes) -> bytes:
+    """Verify an image is Telegram-sendable, always converting to a JPEG.
+
+    Raises ValueError for data PIL cannot fully decode (truncated/corrupt
+    files). Every accepted image is re-encoded as an RGB JPEG capped at 2560px
+    on the long side: WeChat CDN photos occasionally carry PNG/WebP payloads
+    that Telegram's upload path rejects with PHOTO_INVALID_DIMENSIONS, and a
+    deterministic re-encode removes format, dimension and corruption variance
+    in one step.
+    """
+    try:
+        with Image.open(io.BytesIO(data)) as image:
+            width, height = image.size
+            if width <= 0 or height <= 0:
+                raise ValueError(f"invalid image size {width}x{height}")
+            # Telegram rejects photos with an aspect ratio beyond 20:1; WeChat
+            # decorative strips (e.g. 844x18) hit this and fail the whole
+            # media group, so drop them instead.
+            if max(width / height, height / width) > 20:
+                raise ValueError(f"extreme aspect ratio {width}x{height}")
+            image.verify()  # force a full decode; truncated files raise here
+    except ValueError:
+        raise
+    except Exception as e:
+        raise ValueError(f"unreadable image: {e.__class__.__name__}") from e
+    return _resize_image(data)
+
+
+async def download_image(client: httpx.AsyncClient, url: str) -> bytes:
+    """Download one article image; raises when it fails or is unusable."""
+    if not _is_wechat_image_url(url):
+        raise ValueError(f"not a wechat cdn image url: {url!r}")
+    resp = await client.get(url)
+    resp.raise_for_status()
+    data = await resp.aread()
+    if len(data) > 10 * 1024 * 1024:
+        raise ValueError("image too large")
+    return await asyncio.to_thread(_validate_image, data)
+
+
+__all__ = [
+    "WechatArticle",
+    "WECHAT_URL_RE",
+    "build_media_caption",
+    "download_image",
+    "fetch_article",
+    "is_wechat_url",
+    "parse_article_html",
+]

--- a/kmua/webapp/routers/chats.py
+++ b/kmua/webapp/routers/chats.py
@@ -104,6 +104,7 @@ async def update_chat_config(
         parse_artwork_enabled=payload.parse_artwork_enabled,
         pick_bottle_enabled=payload.pick_bottle_enabled,
         group_memory_enabled=payload.group_memory_enabled,
+        parse_wechat_enabled=payload.parse_wechat_enabled,
         rss_agent_summary=payload.rss_agent_summary,
         rss_agent_broadcast=payload.rss_agent_broadcast,
         lang=payload.lang,

--- a/kmua/webapp/schemas.py
+++ b/kmua/webapp/schemas.py
@@ -197,6 +197,7 @@ class ChatConfigOut(ApiModel):
     parse_artwork_enabled: bool
     pick_bottle_enabled: bool
     group_memory_enabled: bool
+    parse_wechat_enabled: bool
     rss_agent_summary: bool
     rss_agent_broadcast: bool
     lang: str
@@ -218,6 +219,7 @@ class ChatConfigIn(ApiModel):
     parse_artwork_enabled: bool
     pick_bottle_enabled: bool
     group_memory_enabled: bool
+    parse_wechat_enabled: bool
     rss_agent_summary: bool
     rss_agent_broadcast: bool
     lang: LocaleStr

--- a/kmua/webapp/serializers.py
+++ b/kmua/webapp/serializers.py
@@ -73,6 +73,7 @@ def chat_config_out(config: ChatConfig) -> ChatConfigOut:
         parse_artwork_enabled=config.parse_artwork_enabled,
         pick_bottle_enabled=config.pick_bottle_enabled,
         group_memory_enabled=config.group_memory_enabled,
+        parse_wechat_enabled=config.parse_wechat_enabled,
         rss_agent_summary=config.rss_agent_summary,
         rss_agent_broadcast=config.rss_agent_broadcast,
         lang=config.lang,

--- a/tests/test_webapp_chat_config.py
+++ b/tests/test_webapp_chat_config.py
@@ -44,6 +44,7 @@ def valid_config(**overrides) -> dict:
         "parse_artwork_enabled": True,
         "pick_bottle_enabled": True,
         "group_memory_enabled": True,
+        "parse_wechat_enabled": True,
         "rss_agent_summary": False,
         "rss_agent_broadcast": False,
         "lang": "zh-CN",

--- a/tests/test_wechat.py
+++ b/tests/test_wechat.py
@@ -1,0 +1,466 @@
+"""WeChat article parsing tests — services layer (pure functions) plus the
+plugin wiring with network and Telegram calls stubbed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from kmua.plugins import wechat as wechat_plugin
+from kmua.services import wechat as wechat_service
+
+# A minimal article page: title, author, publish time, three images.
+_ARTICLE_HTML = """
+<html><head>
+<meta property="og:title" content="测试文章标题">
+<meta property="og:description" content="这是一段描述">
+</head><body>
+<div id="js_name">测试公众号</div>
+<div id="publish_time">2026-07-20 10:30</div>
+<div id="js_content">
+<section><p>第一段正文内容。</p></section>
+<section><p>第二段正文内容, 更详细一点。</p></section>
+<img data-src="https://mmbiz.qpic.cn/mmbiz_jpg/aaa">
+<img src="https://mmbiz.qpic.cn/mmbiz_png/bbb">
+<img src="https://evil.example.com/x.jpg">
+</div>
+</body></html>
+"""
+
+# A share-card/verify page with no body: must fall back to og:description.
+_SHARE_HTML = """
+<html><head>
+<meta property="og:title" content="摘要页标题">
+<meta property="og:description" content="正文摘要文本, 无法获取全文。">
+</head><body><div id="js_name"></div></body></html>
+"""
+
+ARTICLE_URL = "https://mp.weixin.qq.com/s/testid123"
+
+
+# ------------------------------------------------------------------ url checks
+
+
+def test_is_wechat_url_accepts_article_links():
+    assert wechat_service.is_wechat_url("https://mp.weixin.qq.com/s/abc123")
+    assert wechat_service.is_wechat_url("https://mp.weixin.qq.com/s/a-b_c")
+
+
+def test_is_wechat_url_rejects_lookalikes():
+    assert not wechat_service.is_wechat_url("https://evil.com/s/abc123")
+    assert not wechat_service.is_wechat_url("https://mp.weixin.qq.com@evil.com/s/abc")
+    assert not wechat_service.is_wechat_url("https://mp.weixin.qq.com/other/abc")
+    assert not wechat_service.is_wechat_url("http://mp.weixin.qq.com/s/abc")  # http
+
+
+# ------------------------------------------------------------------ parsing
+
+
+def test_parse_article_html_extracts_all_fields():
+    article = wechat_service.parse_article_html(_ARTICLE_HTML, ARTICLE_URL)
+    assert article.title == "测试文章标题"
+    assert article.author == "测试公众号"
+    assert article.published_at is not None
+    assert article.published_at.year == 2026
+    assert article.paragraphs[0] == "第一段正文内容。"
+    # The evil-domain image is rejected, the two mmbiz ones kept.
+    assert len(article.images) == 2
+    assert all("mmbiz.qpic.cn" in u for u in article.images)
+
+
+def test_parse_article_html_falls_back_to_description():
+    article = wechat_service.parse_article_html(_SHARE_HTML, ARTICLE_URL)
+    assert article.title == "摘要页标题"
+    assert article.author is None
+    assert article.paragraphs == ["正文摘要文本, 无法获取全文。"]
+    assert article.images == []
+
+
+def test_download_image_rejects_extreme_aspect_ratio():
+    """Telegram rejects >20:1 photos; such WeChat strips must be dropped."""
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (844, 18), color="red").save(buf, format="JPEG")
+
+    async def fake_get(url):
+        async def fake_aread():
+            return buf.getvalue()
+
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            aread=fake_aread,
+        )
+
+    fake_client = SimpleNamespace(get=fake_get)
+
+    async def run():
+        try:
+            await wechat_service.download_image(fake_client, "https://mmbiz.qpic.cn/1")
+            return None
+        except ValueError as e:
+            return str(e)
+
+    result = asyncio.run(run())
+    assert result and "aspect ratio" in result
+
+
+async def test_download_image_converts_to_jpeg():
+    """Non-JPEG uploads are re-encoded; WeChat PNGs may be rejected otherwise."""
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGBA", (100, 50), color="blue").save(buf, format="PNG")
+
+    async def fake_get(url):
+        async def fake_aread():
+            return buf.getvalue()
+
+        return SimpleNamespace(
+            raise_for_status=lambda: None,
+            aread=fake_aread,
+        )
+
+    fake_client = SimpleNamespace(get=fake_get)
+    data = await wechat_service.download_image(fake_client, "https://mmbiz.qpic.cn/1")
+    with Image.open(io.BytesIO(data)) as im:
+        assert im.format == "JPEG"
+
+
+def test_parse_article_html_limits_images():
+    many_imgs = "".join(
+        f'<img data-src="https://mmbiz.qpic.cn/mmbiz_jpg/{i}">' for i in range(15)
+    )
+    html = f'<html><body><div id="js_content">{many_imgs}</div></body></html>'
+    article = wechat_service.parse_article_html(html, ARTICLE_URL)
+    assert len(article.images) == 10
+
+
+# ------------------------------------------------------------------ formatting
+
+
+def test_build_rich_blocks_interleaves_images_and_quotes():
+    from pyrogram.raw.types.page_block_blockquote import PageBlockBlockquote
+    from pyrogram.raw.types.page_block_heading1 import PageBlockHeading1
+    from pyrogram.raw.types.page_block_photo import PageBlockPhoto
+
+    article = wechat_service.WechatArticle(
+        url=ARTICLE_URL,
+        title="标题",
+        author="作者",
+        blocks=[
+            wechat_service.WechatBlock(kind="text", content="第一段"),
+            wechat_service.WechatBlock(kind="image", content="https://mmbiz.qpic.cn/1"),
+            wechat_service.WechatBlock(kind="text", content="第二段"),
+        ],
+    )
+    # Without photo ids the image block is dropped.
+    blocks = wechat_service.build_rich_blocks(article, lang="zh-CN")
+    assert not any(isinstance(b, PageBlockPhoto) for b in blocks)
+    assert isinstance(blocks[0], PageBlockHeading1)
+    assert any(isinstance(b, PageBlockBlockquote) for b in blocks)
+
+    # With a photo id the image is interleaved at its document position.
+    class FakePhotoRef:
+        id = 42
+
+    blocks2 = wechat_service.build_rich_blocks(
+        article, lang="zh-CN", photo_refs=[FakePhotoRef()]
+    )
+    kinds = [type(b).__name__ for b in blocks2]
+    assert "PageBlockPhoto" in kinds
+    photo_idx = kinds.index("PageBlockPhoto")
+    assert kinds[photo_idx - 1] == "PageBlockBlockquote"  # text before image
+    assert kinds[photo_idx + 1] == "PageBlockBlockquote"  # text after image
+    assert blocks2[photo_idx].photo_id == 42
+
+    # Consecutive paragraphs share one block quote, separated by blank lines.
+    from pyrogram.raw.types.text_plain import TextPlain
+
+    article3 = wechat_service.WechatArticle(
+        url=ARTICLE_URL,
+        blocks=[
+            wechat_service.WechatBlock(kind="text", content="第一段"),
+            wechat_service.WechatBlock(kind="text", content="第二段"),
+            wechat_service.WechatBlock(kind="text", content="第三段"),
+        ],
+    )
+    blocks3 = wechat_service.build_rich_blocks(article3, lang="zh-CN")
+    quotes = [b for b in blocks3 if isinstance(b, PageBlockBlockquote)]
+    assert len(quotes) == 1
+    assert quotes[0].text.text == "第一段\n\n第二段\n\n第三段"
+
+
+def test_build_media_caption_truncates_to_1024():
+    article = wechat_service.WechatArticle(
+        url=ARTICLE_URL,
+        title="标题" * 400,  # long title pushes the caption past 1024
+        paragraphs=["很长的正文" * 500],
+    )
+    caption = wechat_service.build_media_caption(article, lang="zh-CN")
+    assert len(caption) <= 1024
+    assert caption.endswith("…")
+
+
+# ------------------------------------------------------------- plugin wiring
+
+
+@pytest.fixture
+def fake_message():
+    import pyrogram
+
+    class FakeReply:
+        def __init__(self):
+            self.media_groups = []
+            self.texts = []
+
+        async def reply_media_group(self, inputs, **kwargs):
+            self.media_groups.append((inputs, kwargs))
+            return []
+
+        async def reply_text(self, text, **kwargs):
+            self.texts.append((text, kwargs))
+
+        async def reply_chat_action(self, action):
+            pass
+
+    chat = pyrogram.types.Chat(
+        id=-100_123456789, type=pyrogram.enums.ChatType.SUPERGROUP, title="测试群"
+    )
+    user = pyrogram.types.User(id=1001, first_name="Tester")
+    return chat, user, FakeReply()
+
+
+def _make_message(fake_message, url):
+    import pyrogram
+
+    chat, user, reply = fake_message
+    message = pyrogram.types.Message(
+        id=1,
+        chat=chat,
+        from_user=user,
+        text=url,
+        service=False,
+        outgoing=False,
+    )
+    message.matches = [type("M", (), {"group": lambda self: url})()]
+    message.reply_text = reply.reply_text
+    message.reply_media_group = reply.reply_media_group
+    message.reply_chat_action = reply.reply_chat_action
+    return message
+
+
+async def test_plugin_ignores_non_wechat_text(fake_message, monkeypatch):
+    from kmua.database.models import ChatConfig
+
+    async def fake_get_chat_config(chat_id):
+        return ChatConfig(parse_wechat_enabled=True)
+
+    monkeypatch.setattr("kmua.database.get_chat_config", fake_get_chat_config)
+
+    called = []
+
+    async def fake_fetch(url):
+        called.append(url)
+        raise AssertionError("should not be called")
+
+    monkeypatch.setattr(wechat_service, "fetch_article", fake_fetch)
+    chat, user, reply = fake_message
+    message = _make_message(fake_message, "https://example.com/not-wechat")
+    await wechat_plugin.parse_wechat_article(None, message)
+    assert called == []
+
+
+async def test_plugin_disabled_by_chat_config(fake_message, monkeypatch):
+    from kmua.database.models import ChatConfig
+
+    async def fake_get_chat_config(chat_id):
+        return ChatConfig(parse_wechat_enabled=False)
+
+    monkeypatch.setattr("kmua.database.get_chat_config", fake_get_chat_config)
+
+    called = []
+
+    async def fake_fetch(url):
+        called.append(url)
+
+    monkeypatch.setattr(wechat_service, "fetch_article", fake_fetch)
+    message = _make_message(fake_message, "https://mp.weixin.qq.com/s/abc123")
+    await wechat_plugin.parse_wechat_article(None, message)
+    assert called == []
+
+
+async def test_plugin_text_send_for_image_free_article(fake_message, monkeypatch):
+    from kmua.database.models import ChatConfig
+
+    async def fake_get_chat_config(chat_id):
+        return ChatConfig(parse_wechat_enabled=True)
+
+    monkeypatch.setattr("kmua.database.get_chat_config", fake_get_chat_config)
+
+    article = wechat_service.WechatArticle(
+        url="https://mp.weixin.qq.com/s/abc123",
+        title="标题",
+        author="作者",
+        paragraphs=["正文"],
+    )
+
+    async def fake_fetch(url):
+        return article
+
+    rich_calls = []
+
+    async def fake_resolve_peer(chat_id):
+        return SimpleNamespace(user_id=chat_id)
+
+    async def fake_invoke(query, **kwargs):
+        rich_calls.append(query.rich_message)
+
+    fake_client = SimpleNamespace(
+        resolve_peer=fake_resolve_peer,
+        invoke=fake_invoke,
+        rnd_id=lambda: 1,
+    )
+    monkeypatch.setattr(wechat_service, "fetch_article", fake_fetch)
+    message = _make_message(fake_message, "https://mp.weixin.qq.com/s/abc123")
+    await wechat_plugin.parse_wechat_article(fake_client, message)
+
+    assert len(rich_calls) == 1
+    from pyrogram.raw.types.page_block_heading1 import PageBlockHeading1
+
+    assert any(isinstance(b, PageBlockHeading1) for b in rich_calls[0].blocks)
+
+
+async def test_plugin_media_group_send(fake_message, monkeypatch):
+    from kmua.database.models import ChatConfig
+
+    async def fake_get_chat_config(chat_id):
+        return ChatConfig(parse_wechat_enabled=True)
+
+    monkeypatch.setattr("kmua.database.get_chat_config", fake_get_chat_config)
+
+    article = wechat_service.WechatArticle(
+        url="https://mp.weixin.qq.com/s/abc123",
+        title="图文标题",
+        author="作者",
+        paragraphs=["正文"],
+        images=["https://mmbiz.qpic.cn/1", "https://mmbiz.qpic.cn/2"],
+        blocks=[
+            wechat_service.WechatBlock(kind="text", content="正文"),
+            wechat_service.WechatBlock(kind="image", content="https://mmbiz.qpic.cn/1"),
+            wechat_service.WechatBlock(kind="image", content="https://mmbiz.qpic.cn/2"),
+        ],
+    )
+
+    async def fake_fetch(url):
+        return article
+
+    async def fake_download(client, url):
+        return b"fake-image-bytes"
+
+    from pyrogram.raw.functions.messages.upload_media import UploadMedia
+    from pyrogram.raw.types.input_photo import InputPhoto
+    from pyrogram.raw.types.page_block_photo import PageBlockPhoto
+
+    rich_calls = []
+    upload_calls = []
+
+    class FakePhoto:
+        id = 777
+        access_hash = 888
+        file_reference = b"fr"
+
+    async def fake_resolve_peer(chat_id):
+        return SimpleNamespace(user_id=chat_id)
+
+    async def fake_save_file(data):
+        return SimpleNamespace()
+
+    async def fake_invoke(query, **kwargs):
+        if isinstance(query, UploadMedia):
+            upload_calls.append(1)
+            return SimpleNamespace(photo=FakePhoto())
+        rich_calls.append(query.rich_message)
+
+    fake_client = SimpleNamespace(
+        resolve_peer=fake_resolve_peer,
+        invoke=fake_invoke,
+        save_file=fake_save_file,
+        rnd_id=lambda: 1,
+    )
+    monkeypatch.setattr(wechat_service, "fetch_article", fake_fetch)
+    monkeypatch.setattr(wechat_service, "download_image", fake_download)
+    message = _make_message(fake_message, "https://mp.weixin.qq.com/s/abc123")
+    await wechat_plugin.parse_wechat_article(fake_client, message)
+
+    # both images uploaded, then one rich message carrying them inline
+    assert len(upload_calls) == 2
+    assert len(rich_calls) == 1
+    rich = rich_calls[0]
+    assert rich.photos and isinstance(rich.photos[0], InputPhoto)
+    assert rich.photos[0].id == 777
+    photo_blocks = [b for b in rich.blocks if isinstance(b, PageBlockPhoto)]
+    assert len(photo_blocks) == 2
+    assert all(b.photo_id == 777 for b in photo_blocks)
+
+
+async def test_plugin_falls_back_to_text_when_images_fail(fake_message, monkeypatch):
+    from kmua.database.models import ChatConfig
+
+    async def fake_get_chat_config(chat_id):
+        return ChatConfig(parse_wechat_enabled=True)
+
+    monkeypatch.setattr("kmua.database.get_chat_config", fake_get_chat_config)
+
+    article = wechat_service.WechatArticle(
+        url="https://mp.weixin.qq.com/s/abc123",
+        title="标题",
+        paragraphs=["正文"],
+        images=["https://mmbiz.qpic.cn/1"],
+        blocks=[
+            wechat_service.WechatBlock(kind="text", content="正文"),
+            wechat_service.WechatBlock(kind="image", content="https://mmbiz.qpic.cn/1"),
+        ],
+    )
+
+    async def fake_fetch(url):
+        return article
+
+    async def fake_download(client, url):
+        return b"fake-image-bytes"
+
+    media_calls = []
+
+    async def fake_send_media_group(chat_id, media, **kwargs):
+        media_calls.append(media)
+
+    async def fake_resolve_peer(chat_id):
+        return SimpleNamespace(user_id=chat_id)
+
+    async def fake_save_file(data):
+        return SimpleNamespace()
+
+    async def fake_invoke(query, **kwargs):
+        raise RuntimeError("rich send broken")
+
+    fake_client = SimpleNamespace(
+        send_media_group=fake_send_media_group,
+        resolve_peer=fake_resolve_peer,
+        invoke=fake_invoke,
+        save_file=fake_save_file,
+        rnd_id=lambda: 1,
+    )
+    monkeypatch.setattr(wechat_service, "fetch_article", fake_fetch)
+    monkeypatch.setattr(wechat_service, "download_image", fake_download)
+    message = _make_message(fake_message, "https://mp.weixin.qq.com/s/abc123")
+    await wechat_plugin.parse_wechat_article(fake_client, message)
+
+    # rich upload/send failed: fell back to the media group
+    assert len(media_calls) == 1

--- a/webapp/src/api/types.ts
+++ b/webapp/src/api/types.ts
@@ -125,6 +125,7 @@ export interface ChatConfig {
   parse_artwork_enabled: boolean;
   pick_bottle_enabled: boolean;
   group_memory_enabled: boolean;
+  parse_wechat_enabled: boolean;
   rss_agent_summary: boolean;
   rss_agent_broadcast: boolean;
   lang: string;

--- a/webapp/src/i18n/en.json
+++ b/webapp/src/i18n/en.json
@@ -151,6 +151,7 @@
     "pick_bottle_enabled": "Pick drift bottles",
     "group_memory_enabled": "Group memory",
     "group_memory_enabledHint": "Let kmua remember this group's conversations",
+    "parse_wechat_enabled": "Parse WeChat articles",
     "rss_agent_summary": "AI summary on RSS pushes",
     "rss_agent_broadcast": "AI broadcast on new RSS entries"
   },

--- a/webapp/src/i18n/zh-CN.json
+++ b/webapp/src/i18n/zh-CN.json
@@ -151,6 +151,7 @@
     "pick_bottle_enabled": "捡漂流瓶",
     "group_memory_enabled": "群组记忆",
     "group_memory_enabledHint": "让 kmua 记住这个群的对话内容",
+    "parse_wechat_enabled": "解析微信公众号文章",
     "rss_agent_summary": "RSS 推送 AI 摘要",
     "rss_agent_broadcast": "RSS AI 播报"
   },

--- a/webapp/src/views/chats/ChatConfigView.vue
+++ b/webapp/src/views/chats/ChatConfigView.vue
@@ -56,6 +56,7 @@ const EMPTY_CONFIG: ChatConfigInput = {
   parse_artwork_enabled: true,
   pick_bottle_enabled: true,
   group_memory_enabled: true,
+  parse_wechat_enabled: true,
   rss_agent_summary: false,
   rss_agent_broadcast: false,
   lang: "zh-CN",

--- a/webapp/src/views/chats/config-layout.ts
+++ b/webapp/src/views/chats/config-layout.ts
@@ -45,6 +45,7 @@ export const TOGGLE_GROUPS: ToggleGroup[] = [
       "setu_enabled",
       "convert_b23_enabled",
       "parse_artwork_enabled",
+      "parse_wechat_enabled",
       "message_search_enabled",
     ],
   },


### PR DESCRIPTION

Fetched mp.weixin.qq.com pages and extracted title, author, body and images in document order. Sent one MTProto rich message with structured blocks: heading, merged block quotes and inline photos at their original positions. Uploaded images via messages.UploadMedia and referenced them as InputPhoto ids. Added a per-chat ChatConfig switch exposed in the webapp panel. Excluded WeChat links from the keyword-reply and agent wake filters.