### PR TITLE
feat: delivered user interjections into the running agent turn

### DIFF
--- a/kmua/plugins/agent/agent.py
+++ b/kmua/plugins/agent/agent.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+from typing import Any
 
 import pyrogram
 from aiocache import SimpleMemoryCache
@@ -65,6 +66,50 @@ if app_config.agent_powermem_config is not None:
 
 
 _bot_user_wake_locks: dict[int, asyncio.Lock] = {}
+# Runs currently executing, keyed by conversation. /clear_sessions cancels
+# them so a wiped conversation is not written back to afterwards.
+_active_run_tasks: dict[tuple[int, int], asyncio.Task] = {}
+
+
+async def _queue_interjection(
+    message: pyrogram.types.Message, chat_id: int, user_id: int
+) -> None:
+    """Queue a mid-turn message for the running conversation.
+
+    Delivers straight into the live AgentRun's pending-message queue (same
+    event loop), so the very next model request - or the end-of-run redirect
+    - carries it. Falls back to the steering queue while a run is starting
+    or winding down.
+    """
+    text = (message.text or message.caption or "").strip()
+    if not text:
+        return
+    if state.enqueue_interjection(chat_id, user_id, text):
+        logger.info(
+            f"User {user_id} interjected in chat {chat_id}; delivered "
+            f"into the running turn"
+        )
+        return
+    await message.reply_text("「回复不过来啦, 请稍等一会吧...」")
+
+
+async def _run_registered(chat_id: int, user_id: int, coro) -> Any:
+    """Run a turn under the task registry; cancellable by session cleanup."""
+    key = (chat_id, user_id)
+    task = asyncio.create_task(coro)
+    _active_run_tasks[key] = task
+    try:
+        return await task
+    except asyncio.CancelledError:
+        logger.info(
+            f"Agent run cancelled for user {user_id} in chat {chat_id} "
+            f"by session cleanup"
+        )
+        return None
+    finally:
+        if _active_run_tasks.get(key) is task:
+            del _active_run_tasks[key]
+
 
 _BOT_WAKE_DELAY_MIN_SECONDS = 0.721
 _BOT_WAKE_DELAY_MAX_SECONDS = 12.7
@@ -106,6 +151,7 @@ async def _clear_conversation_session(chat_id: int, user_id: int) -> None:
     await common.memttlcache.delete(state.history_key(chat_id, user_id))
     await tools.clear_ask_state(chat_id, user_id)
     safety.delete_spill_session(f"{chat_id}_{user_id}")
+    state.clear_steering(chat_id, user_id)
     if chat_id == user_id:
         from kmua.plugins.agent.tools import workspace as workspace_tools
         from kmua.services import sandbox
@@ -293,31 +339,42 @@ if app_config.agent and app_config.agent_model:
         if prompt_override:
             instructions = prompt_override
 
-        await common.memstore.set(state.waiting_key(user_id), True)
+        ask_lock = state.get_conversation_lock(chat_id, user_id)
+        if ask_lock.locked():
+            logger.info(
+                f"Ask run skipped for user {user_id} in chat {chat_id}: "
+                f"turn already in flight"
+            )
+            return
+        await ask_lock.acquire()
         try:
-            await runner.run_agent(
-                agi=agent,  # type: ignore
-                client=client,
-                message=message,
-                user_id=user_id,
-                chat_id=chat_id,
-                user_prompt=[user_prompt],
-                history=history,
-                deps=datatype.ContextDeps(
+            await _run_registered(
+                chat_id,
+                user_id,
+                runner.run_agent(
+                    agi=agent,  # type: ignore
+                    client=client,
+                    message=message,
                     user_id=user_id,
                     chat_id=chat_id,
-                    message=message,
-                    client=client,
-                    instructions=instructions,
-                    powermemory=powermemory,
+                    user_prompt=[user_prompt],
                     history=history,
+                    deps=datatype.ContextDeps(
+                        user_id=user_id,
+                        chat_id=chat_id,
+                        message=message,
+                        client=client,
+                        instructions=instructions,
+                        powermemory=powermemory,
+                        history=history,
+                    ),
+                    multimodal_model=multimodal_model,
+                    model=model,
+                    lang=lang,
                 ),
-                multimodal_model=multimodal_model,
-                model=model,
-                lang=lang,
             )
         finally:
-            await common.memstore.delete(state.waiting_key(user_id))
+            ask_lock.release()
 
     tools.set_run_callback(_run_agent_for_ask)
 
@@ -329,13 +386,13 @@ if app_config.agent and app_config.agent_model:
         if not user or user.id is None:
             return
         user_config = await database.get_user_config(user.id)
-        if await common.memstore.get(state.waiting_key(user.id)):
+        chat_id = message.chat.id if message.chat else user.id
+        if not chat_id:
+            return
+        if state.is_running(chat_id, user.id):
             await message.reply_text(
                 i18n.t("bot.msg.agent.waiting", locale=user_config.lang)
             )
-            return
-        chat_id = message.chat.id if message.chat else user.id
-        if not chat_id:
             return
         if not is_chat_allowed(chat_id):
             return
@@ -369,9 +426,15 @@ if app_config.agent and app_config.agent_model:
                 "cannot be undone. Run /clear_sessions confirm to proceed."
             )
             return
+        active_runs = [t for t in _active_run_tasks.values() if not t.done()]
+        for task in active_runs:
+            task.cancel()
+        if active_runs:
+            await asyncio.gather(*active_runs, return_exceptions=True)
         histories = await _clear_memttlcache_prefix("message_history_with_agent:")
-        waits = _clear_memstore_prefix("agent_waiting:")
         asks = _clear_memstore_prefix("agent_ask_state:")
+        steered = state.clear_all_steering()
+        state.clear_all_locks()
         spills = safety.clear_all_spills()
         from kmua.plugins.agent.tools import workspace as workspace_tools
         from kmua.services import sandbox
@@ -383,14 +446,15 @@ if app_config.agent and app_config.agent_model:
         persisted = await persistent_file_db.delete_all_persistent_files()
         logger.info(
             f"All agent sessions cleared by {user.id}: "
-            f"histories={histories} waits={waits} asks={asks} spills={spills} "
-            f"shells={shells} workspaces={workspaces} persisted={persisted}"
+            f"histories={histories} asks={asks} spills={spills} "
+            f"steered={steered} shells={shells} workspaces={workspaces} "
+            f"persisted={persisted}"
         )
         await message.reply_text(
             f"Cleared {histories} conversation histories, {asks} pending "
-            f"questions, {spills} stored overflow entries, {shells} shell "
-            f"workspaces, {workspaces} workspace databases, {persisted} "
-            f"persisted files (chat messages stay)."
+            f"questions, {spills} stored overflow entries, {steered} queued "
+            f"messages, {shells} shell workspaces, {workspaces} workspace "
+            f"databases, {persisted} persisted files (chat messages stay)."
         )
 
     @PyrogramClient.on_callback_query(
@@ -769,13 +833,14 @@ async def wake_agent(client: PyrogramClient, message: pyrogram.types.Message):
         await bot_user_wake_lock.acquire()
         bot_user_wake_lock_acquired = True
 
-    waiting_marked = False
+    conv_lock = state.get_conversation_lock(chat.id, user.id)
+    if conv_lock.locked():
+        if is_bot_user:
+            return
+        await _queue_interjection(message, chat.id, user.id)
+        return
+    await conv_lock.acquire()
     try:
-        if await common.memstore.get(state.waiting_key(user.id)):
-            if is_bot_user:
-                return
-            return await message.reply_text("Thinking...")
-
         # Check if there's a pending ask — clear it and let the normal flow handle
         # the new message (the ask context is already in history).
         ask_state = await tools.get_ask_state(chat.id, user.id)
@@ -785,8 +850,6 @@ async def wake_agent(client: PyrogramClient, message: pyrogram.types.Message):
                 f"Cleared pending ask for user {user.id}, proceeding with normal agent run"
             )
 
-        await common.memstore.set(state.waiting_key(user.id), True)
-        waiting_marked = True
         # set language
         if chat.type == pyrogram.enums.ChatType.PRIVATE:
             lang = (await database.get_user_config(user.id)).lang
@@ -826,6 +889,7 @@ async def wake_agent(client: PyrogramClient, message: pyrogram.types.Message):
             history=history,
             is_group_chat=is_group_chat,
         )
+        ctx_info_text = ctx_info.to_text() if ctx_info else None
         # 在群聊场景中获取附近消息作为上下文
         # [TODO] 好像自动添加附近消息反而效果不好了
         nearby_count = (
@@ -834,33 +898,47 @@ async def wake_agent(client: PyrogramClient, message: pyrogram.types.Message):
         user_prompt, _ = await get_input_prompt(
             client, message, include_nearby=nearby_count, ctx=None
         )
+        stale_steering = state.drain_steering(chat.id, user.id)
+        if stale_steering:
+            user_prompt = [*user_prompt, "\n".join(stale_steering)]
+            logger.info(
+                f"User {user.id} has {len(stale_steering)} queued message(s) "
+                f"from before, folded into this turn in chat {chat.id}"
+            )
         user_message_text = message.text or message.caption or ""
         if user_message_text:
             logger.debug(
                 f"User {user.id} wake agent in Chat {chat.id}: {user_message_text}"
             )
         await utils.cache_user_image(message, chat_id, user.id)
-        await run_agent(
-            agi=agent,
-            additional_instructions=ctx_info.to_text() if ctx_info else None,
-            client=client,
-            message=message,
-            user_id=user.id,
-            chat_id=chat_id,
-            user_prompt=user_prompt,
-            history=history,
-            deps=datatype.ContextDeps(
+        # Interjections arriving mid-run are delivered by the pending-message
+        # queue inside the same run (see SteeringInjection); no follow-up
+        # run is spawned, so run quotas and the timeout stay continuous.
+        await _run_registered(
+            chat_id,
+            user.id,
+            run_agent(
+                agi=agent,
+                additional_instructions=ctx_info_text,
+                client=client,
+                message=message,
                 user_id=user.id,
                 chat_id=chat_id,
-                message=message,
-                client=client,
-                instructions=instructions,
-                powermemory=powermemory,
+                user_prompt=user_prompt,
                 history=history,
-            ),  # type: ignore
-            multimodal_model=multimodal_model,
-            model=model,
-            lang=lang,
+                deps=datatype.ContextDeps(
+                    user_id=user.id,
+                    chat_id=chat_id,
+                    message=message,
+                    client=client,
+                    instructions=instructions,
+                    powermemory=powermemory,
+                    history=history,
+                ),  # type: ignore
+                multimodal_model=multimodal_model,
+                model=model,
+                lang=lang,
+            ),
         )
         # Increment periodic counters after each completed conversation turn.
         if app_config.agent_periodic_sticker_interval > 0:
@@ -879,8 +957,7 @@ async def wake_agent(client: PyrogramClient, message: pyrogram.types.Message):
                 reaction_ctr + 1,
             )
     finally:
-        if waiting_marked:
-            await common.memstore.delete(state.waiting_key(user.id))
+        conv_lock.release()
         if bot_user_wake_lock_acquired and bot_user_wake_lock is not None:
             bot_user_wake_lock.release()
 
@@ -904,7 +981,9 @@ async def on_guest_chat_query(
     if not is_chat_allowed(chat.id):
         return
 
-    if await common.memstore.get(state.waiting_key(user.id)):
+    guest_lock = state.get_conversation_lock(chat.id, user.id)
+    if guest_lock.locked():
+        await _queue_interjection(message, chat.id, user.id)
         return
 
     user_data = await database.get_user_by_id(user.id)
@@ -913,7 +992,7 @@ async def on_guest_chat_query(
     if await tools.is_user_blocked(user.id):
         return
 
-    await common.memstore.set(state.waiting_key(user.id), True)
+    await guest_lock.acquire()
     try:
         user_message_text = message.text or message.caption or ""
         if user_message_text:
@@ -951,29 +1030,33 @@ async def on_guest_chat_query(
             client, message, include_nearby=0, ctx=None
         )
 
-        await run_agent(
-            agi=agent,  # type: ignore[arg-type]
-            additional_instructions=ctx_info.to_text() if ctx_info else None,
-            client=client,
-            message=message,
-            user_id=user.id,
-            chat_id=chat.id,
-            user_prompt=user_prompt,
-            history=history,
-            deps=datatype.ContextDeps(
+        await _run_registered(
+            chat.id,
+            user.id,
+            run_agent(
+                agi=agent,  # type: ignore[arg-type]
+                additional_instructions=ctx_info.to_text() if ctx_info else None,
+                client=client,
+                message=message,
                 user_id=user.id,
                 chat_id=chat.id,
-                message=message,
-                client=client,
-                instructions=instructions,
-                powermemory=powermemory,
+                user_prompt=user_prompt,
                 history=history,
+                deps=datatype.ContextDeps(
+                    user_id=user.id,
+                    chat_id=chat.id,
+                    message=message,
+                    client=client,
+                    instructions=instructions,
+                    powermemory=powermemory,
+                    history=history,
+                ),
+                multimodal_model=multimodal_model,
+                model=model,
+                lang=user_data.user_config.lang
+                if user_data.user_config
+                else app_config.lang,
             ),
-            multimodal_model=multimodal_model,
-            model=model,
-            lang=user_data.user_config.lang
-            if user_data.user_config
-            else app_config.lang,
         )
     finally:
-        await common.memstore.delete(state.waiting_key(user.id))
+        guest_lock.release()

--- a/kmua/plugins/agent/followup.py
+++ b/kmua/plugins/agent/followup.py
@@ -17,7 +17,15 @@ from kmua.plugins.agent.runner import (
     run_agent,
 )
 
-from .agent import agent, model, multimodal_model, powermemory, small_model
+from .agent import (
+    _queue_interjection,
+    _run_registered,
+    agent,
+    model,
+    multimodal_model,
+    powermemory,
+    small_model,
+)
 from .tools import block as tools
 from .whitelist import is_chat_allowed
 
@@ -115,7 +123,16 @@ async def _follow_up_filter_func(
         )
         if has_mention:
             return False
-    if await common.memstore.get(state.waiting_key(user.id)):
+    if chat is not None and chat.id is not None and state.is_running(chat.id, user.id):
+        # Mid-turn: the message is an interjection, not a follow-up trigger.
+        # Deliver it straight into the live run (budget-checked), so the
+        # running turn picks it up on its next model request.
+        text = (message.text or message.caption or "").strip()
+        if text and not state.enqueue_interjection(chat.id, user.id, text):
+            logger.warning(
+                f"Follow-up interjection dropped for user {user.id} in "
+                f"chat {chat.id}: interjection budget exhausted"
+            )
         return False
     return True
 
@@ -212,10 +229,12 @@ Bot回复: {bot_full_output}
     logger.info(
         f"Detected follow-up message {message.id} (reason: {relevance_result.output.reason})"  # type: ignore[union-attr]
     )
-    if await common.memstore.get(state.waiting_key(user.id)):
+    follow_lock = state.get_conversation_lock(chat.id, user.id)
+    if follow_lock.locked():
+        await _queue_interjection(message, chat.id, user.id)
         return
+    await follow_lock.acquire()
     try:
-        await common.memstore.set(state.waiting_key(user.id), True)
         await message.reply_chat_action(pyrogram.enums.ChatAction.TYPING)
         instructions = (
             app_config.agent_group_prompt
@@ -250,27 +269,31 @@ Bot回复: {bot_full_output}
 ---
 现在又有用户[{user_data.full_name}]对这个话题继续讨论，请自然地参与对话。
 """
-        await run_agent(
-            agi=agent,
-            additional_instructions=addtional_instructions,
-            client=client,
-            message=message,
-            user_id=user.id,
-            chat_id=chat.id,
-            user_prompt=follow_up_prompt,
-            history=history,
-            deps=datatype.ContextDeps(
+        await _run_registered(
+            chat.id,
+            user.id,
+            run_agent(
+                agi=agent,
+                additional_instructions=addtional_instructions,
+                client=client,
+                message=message,
                 user_id=user.id,
                 chat_id=chat.id,
-                message=message,
-                client=client,
-                instructions=instructions,
-                powermemory=powermemory,
+                user_prompt=follow_up_prompt,
                 history=history,
+                deps=datatype.ContextDeps(
+                    user_id=user.id,
+                    chat_id=chat.id,
+                    message=message,
+                    client=client,
+                    instructions=instructions,
+                    powermemory=powermemory,
+                    history=history,
+                ),
+                multimodal_model=multimodal_model,
+                model=model,
+                lang=chat_config.lang,
             ),
-            multimodal_model=multimodal_model,
-            model=model,
-            lang=chat_config.lang,
         )
 
     except Exception as e:
@@ -278,4 +301,4 @@ Bot回复: {bot_full_output}
             f"Error handling follow-up message: {e.__class__.__name__} - {e}"
         )
     finally:
-        await common.memstore.delete(state.waiting_key(user.id))
+        follow_lock.release()

--- a/kmua/plugins/agent/runner.py
+++ b/kmua/plugins/agent/runner.py
@@ -121,8 +121,13 @@ async def _iter_with_spill_session(
             deps=deps,
             usage_limits=usage_limits,
         ) as agent_run:
+            # Interjections enqueue straight into this run (see
+            # state.get_active_run), so the pending-message drain delivers
+            # them on the next model request without a hook round-trip.
+            state.register_active_run(chat_id, user_id, agent_run)
             yield agent_run
     finally:
+        state.unregister_active_run(chat_id, user_id)
         safety.reset_spill_session(token)
 
 
@@ -278,7 +283,8 @@ async def _run_agent_impl(
                         deps=deps,
                         usage_limits=safety.build_usage_limits(),
                     ) as agent_run:
-                        async for node in agent_run:
+                        node = agent_run.next_node
+                        while not Agent.is_end_node(node):
                             if Agent.is_model_request_node(node):
                                 # Tool returns are only visible as request parts —
                                 # they never appear in the response event stream.
@@ -321,34 +327,33 @@ async def _run_agent_impl(
                                 if has_tool_calls and streaming_output is not None:
                                     await streaming_output.finalize()
                                     streaming_output = None
-                            elif Agent.is_end_node(node):
-                                assert agent_run.result is not None, (
-                                    "Agent run ended without result"
+                            # next() runs the full capability lifecycle
+                            # (before/wrap/after_node_run), which drains
+                            # end-of-run pending messages into a redirect
+                            # instead of stranding them.
+                            node = await agent_run.next(node)
+                        assert agent_run.result is not None, (
+                            "Agent run ended without result"
+                        )
+                        logger.debug(
+                            f"Agent run end with result: {agent_run.result.output}"
+                        )
+                        output = agent_run.result.output
+                        if isinstance(output, (EndTurn, AskUserOutput)):
+                            if streaming_output is not None:
+                                await streaming_output.abort()
+                        else:
+                            # Check final_result first before sending anything
+                            if isinstance(output, str) and "final_result" in output:
+                                if streaming_output is not None:
+                                    await streaming_output.abort()
+                                logger.warning(
+                                    f"The stupid agent returned 'final_result' as text🤡 for user {user_id}"
                                 )
-                                logger.debug(
-                                    f"Agent run end with result: {agent_run.result.output}"
-                                )
-                                output = agent_run.result.output
-                                if isinstance(output, (EndTurn, AskUserOutput)):
-                                    if streaming_output is not None:
-                                        await streaming_output.abort()
-                                else:
-                                    # Check final_result first before sending anything
-                                    if (
-                                        isinstance(output, str)
-                                        and "final_result" in output
-                                    ):
-                                        if streaming_output is not None:
-                                            await streaming_output.abort()
-                                        logger.warning(
-                                            f"The stupid agent returned 'final_result' as text🤡 for user {user_id}"
-                                        )
-                                    elif streaming_output is not None:
-                                        await streaming_output.finalize()
-                                    elif output:
-                                        await reply_output(
-                                            client, message, output, deps=deps
-                                        )
+                            elif streaming_output is not None:
+                                await streaming_output.finalize()
+                            elif output:
+                                await reply_output(client, message, output, deps=deps)
                         # Save full output for follow-up detection
                         full_output = ""
                         if streaming_output is not None:
@@ -403,7 +408,8 @@ async def _run_agent_impl(
                     replied = False
                     full_output_parts: list[str] = []
                     output: Any = None
-                    async for node in agent_run:
+                    node = agent_run.next_node
+                    while not Agent.is_end_node(node):
                         if Agent.is_call_tools_node(node):
                             for part in node.model_response.parts:
                                 if part.part_kind == "tool-call":
@@ -429,36 +435,36 @@ async def _run_agent_impl(
                                     _log_tool_return(
                                         part.tool_name, part.content, user_id, chat_id
                                     )
-                        elif Agent.is_end_node(node):
-                            assert agent_run.result is not None, (
-                                "Agent run ended without result"
-                            )
-                            logger.info(
-                                f"Agent run end for user {user_id} in chat {chat_id} "
-                                f"({len(_tool_call_log)} tool call(s) pending in log)"
-                            )
-                            logger.debug(
-                                f"Agent run end with result: {agent_run.result.output}"
-                            )
-                            output = agent_run.result.output
-                            if isinstance(output, str) and "final_result" in output:
-                                logger.warning(
-                                    f"The stupid agent returned 'final_result' as text🤡 for user {user_id}"
-                                )
-                            elif isinstance(output, (EndTurn, AskUserOutput)):
-                                logger.debug(
-                                    f"Agent returned {type(output).__name__} for user {user_id}"
-                                )
-                            elif not replied and output:
-                                if not is_guest_mode:
-                                    await reply_output(client, message, output)
-                                full_output_parts.append(output)
-                            # In guest mode, send a single collected reply at the end
-                            if is_guest_mode and full_output_parts:
-                                full_text = "\n".join(full_output_parts)
-                                await reply_output(
-                                    client, message, full_text, deps=deps
-                                )
+                        # next() runs the full capability lifecycle, which
+                        # drains end-of-run pending messages into a redirect.
+                        node = await agent_run.next(node)
+                    assert agent_run.result is not None, (
+                        "Agent run ended without result"
+                    )
+                    logger.info(
+                        f"Agent run end for user {user_id} in chat {chat_id} "
+                        f"({len(_tool_call_log)} tool call(s) pending in log)"
+                    )
+                    logger.debug(
+                        f"Agent run end with result: {agent_run.result.output}"
+                    )
+                    output = agent_run.result.output
+                    if isinstance(output, str) and "final_result" in output:
+                        logger.warning(
+                            f"The stupid agent returned 'final_result' as text🤡 for user {user_id}"
+                        )
+                    elif isinstance(output, (EndTurn, AskUserOutput)):
+                        logger.debug(
+                            f"Agent returned {type(output).__name__} for user {user_id}"
+                        )
+                    elif not replied and output:
+                        if not is_guest_mode:
+                            await reply_output(client, message, output)
+                        full_output_parts.append(output)
+                    # In guest mode, send a single collected reply at the end
+                    if is_guest_mode and full_output_parts:
+                        full_text = "\n".join(full_output_parts)
+                        await reply_output(client, message, full_text, deps=deps)
                     # Save full output for follow-up detection
                     full_output = "\n".join(full_output_parts)
                     if (

--- a/kmua/plugins/agent/safety.py
+++ b/kmua/plugins/agent/safety.py
@@ -19,7 +19,9 @@ from contextvars import ContextVar, Token
 from datetime import timedelta
 from typing import Any
 
-from pydantic_ai.capabilities import ProcessHistory
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import AbstractCapability, ProcessHistory
+from pydantic_ai.models import ModelRequestContext
 from pydantic_ai.usage import UsageLimits
 from pydantic_ai_harness.compaction import ClampOversizedMessages, WarnNearLimits
 from pydantic_ai_harness.guardrails import (
@@ -39,8 +41,10 @@ from pydantic_ai_harness.tool_output_limits import (
 )
 
 from kmua.config import app_config
+from kmua.logger import logger
 
 from .model_log import ModelActivityLog
+from .state import drain_steering
 
 _scrub_text_output = for_text(redact_secrets, on_other="allow")
 
@@ -191,6 +195,35 @@ def _clamp_max_part_tokens() -> int:
     return 50_000
 
 
+class SteeringInjection(AbstractCapability[Any]):
+    """Deliver queued user interjections through the official pending-message
+    queue.
+
+    ``RunContext.enqueue`` with the default ``asap`` priority is drained by
+    pydantic-ai's auto-injected PendingMessageDrainCapability: into the very
+    next model request, or - when the agent would otherwise end - through a
+    redirected request in the SAME run. Quotas, timeout and usage counters
+    therefore stay continuous across interjections; nothing is cancelled and
+    no follow-up run is spawned.
+    """
+
+    async def before_model_request(
+        self,
+        ctx: RunContext[Any],
+        request_context: ModelRequestContext,
+    ) -> ModelRequestContext:
+        pending = drain_steering(ctx.deps.chat_id, ctx.deps.user_id)
+        if not pending:
+            return request_context
+        for text in pending:
+            ctx.enqueue(text, priority="asap")
+        logger.info(
+            f"Queued {len(pending)} steering message(s) into the run for "
+            f"user {ctx.deps.user_id} in chat {ctx.deps.chat_id}"
+        )
+        return request_context
+
+
 def build_agent_capabilities(history_processor: Any) -> list[Any]:
     """Assemble the main agent's capabilities from config.
 
@@ -198,7 +231,11 @@ def build_agent_capabilities(history_processor: Any) -> list[Any]:
     ``agent_secret_masking`` / ``agent_tool_output_limit`` switches; spill
     mode registers the harness's read_tool_result tool.
     """
-    caps: list[Any] = [ProcessHistory(history_processor), ModelActivityLog()]
+    caps: list[Any] = [
+        ProcessHistory(history_processor),
+        ModelActivityLog(),
+        SteeringInjection(),
+    ]
     if app_config.agent_secret_masking:
         caps.append(ToolGuardrail(result_guard=scrub_tool_result))
         caps.append(OutputGuardrail(guard=scrub_output))

--- a/kmua/plugins/agent/state.py
+++ b/kmua/plugins/agent/state.py
@@ -1,9 +1,47 @@
+import asyncio
+from typing import Any
+
+
 def history_key(chat_id: int, user_id: int) -> str:
     return f"message_history_with_agent:{chat_id}:{user_id}"
 
 
 def waiting_key(user_id: int) -> str:
     return f"agent_waiting:{user_id}"
+
+
+# Per-conversation turn ownership. The wake/ask/guest/follow-up entries
+# acquire the lock for the whole run; a second message finding it locked is
+# an interjection and gets queued instead of starting a concurrent run.
+_conversation_locks: dict[tuple[int, int], asyncio.Lock] = {}
+
+
+_MAX_CONVERSATION_LOCKS = 512
+
+
+def get_conversation_lock(chat_id: int, user_id: int) -> asyncio.Lock:
+    """The (chat, user) turn lock, created on first use.
+
+    Unlocked locks are pruned once the registry outgrows a bound, so long
+    runs with many distinct conversations do not grow without limit. A
+    locked (in-flight) lock is never pruned.
+    """
+    key = (chat_id, user_id)
+    lock = _conversation_locks.get(key)
+    if lock is None:
+        if len(_conversation_locks) >= _MAX_CONVERSATION_LOCKS:
+            for existing_key, existing in list(_conversation_locks.items()):
+                if not existing.locked():
+                    del _conversation_locks[existing_key]
+        lock = asyncio.Lock()
+        _conversation_locks[key] = lock
+    return lock
+
+
+def is_running(chat_id: int, user_id: int) -> bool:
+    """Whether a turn is in flight for this conversation."""
+    lock = _conversation_locks.get((chat_id, user_id))
+    return lock is not None and lock.locked()
 
 
 def bot_last_reply_key(chat_id: int) -> str:
@@ -72,3 +110,112 @@ def user_blocked_key(user_id: int) -> str:
 def user_block_immune_key(user_id: int) -> str:
     """Whether the user is immune to being blocked by the agent."""
     return f"agent_user_block_immune:{user_id}"
+
+
+# Interjections: messages the user sends while their agent turn is running.
+# Delivered straight into the live AgentRun (state.enqueue_interjection);
+# this queue only covers the window before a run is registered or after it
+# ends. A capability drains it as a fallback.
+_steering_messages: dict[tuple[int, int], list[str]] = {}
+
+
+_MAX_STEERING_MESSAGES = 20
+_MAX_STEERING_CHARS = 8000
+
+
+def queue_steering(chat_id: int, user_id: int, text: str) -> bool:
+    """Queue a user interjection for the running turn.
+
+    Bounded: an over-limit queue rejects the newest message instead of
+    growing without limit into an oversized model request. Returns False
+    when the message was not queued so the caller can tell the user.
+    """
+    from kmua.logger import logger
+
+    key = (chat_id, user_id)
+    queue = _steering_messages.setdefault(key, [])
+    if len(queue) >= _MAX_STEERING_MESSAGES or (
+        sum(len(item) for item in queue) + len(text) > _MAX_STEERING_CHARS
+    ):
+        logger.warning(
+            f"Steering queue full for chat {chat_id} user {user_id}; "
+            f"dropping the newest message"
+        )
+        return False
+    queue.append(text)
+    return True
+
+
+def drain_steering(chat_id: int, user_id: int) -> list[str]:
+    """Take and clear the queued interjections for a conversation."""
+    return _steering_messages.pop((chat_id, user_id), [])
+
+
+def peek_steering(chat_id: int, user_id: int) -> list[str]:
+    """Copy of the queued interjections without clearing them."""
+    return list(_steering_messages.get((chat_id, user_id), []))
+
+
+def clear_steering(chat_id: int, user_id: int) -> None:
+    """Drop the queued interjections of one conversation (history cleared),
+    and its interjection budget so a fresh run starts with a full quota."""
+    _steering_messages.pop((chat_id, user_id), None)
+    _interjection_budget.pop((chat_id, user_id), None)
+
+
+def clear_all_steering() -> int:
+    count = sum(len(q) for q in _steering_messages.values())
+    _steering_messages.clear()
+    _interjection_budget.clear()
+    return count
+
+
+# The AgentRun currently executing for each conversation. Interjections
+# enqueue into it directly (same event loop, safe from any task), so the
+# pending-message drain delivers them on the very next model request - or
+# via the end-of-run redirect - without waiting for a capability hook.
+_active_runs: dict[tuple[int, int], Any] = {}
+
+
+def register_active_run(chat_id: int, user_id: int, agent_run: Any) -> None:
+    _active_runs[(chat_id, user_id)] = agent_run
+
+
+def unregister_active_run(chat_id: int, user_id: int) -> None:
+    _active_runs.pop((chat_id, user_id), None)
+    _interjection_budget.pop((chat_id, user_id), None)
+
+
+def get_active_run(chat_id: int, user_id: int) -> Any | None:
+    return _active_runs.get((chat_id, user_id))
+
+
+# Per-run interjection budget: the same caps as the steering queue apply to
+# direct enqueue calls, so a run cannot accumulate unbounded pending input.
+_interjection_budget: dict[tuple[int, int], tuple[int, int]] = {}
+
+
+def enqueue_interjection(chat_id: int, user_id: int, text: str) -> bool:
+    """Budget-checked enqueue into the live AgentRun (or the fallback queue).
+
+    A run whose graph already ended (``result`` populated) is not enqueued
+    into: its pending queue would never be drained. Returns False when the
+    budget is exhausted or the fallback queue rejects; the budget is only
+    charged on success and resets when the run ends.
+    """
+    key = (chat_id, user_id)
+    count, chars = _interjection_budget.get(key, (0, 0))
+    if count >= _MAX_STEERING_MESSAGES or (chars + len(text) > _MAX_STEERING_CHARS):
+        return False
+    run = _active_runs.get(key)
+    if run is not None and run.result is None:
+        run.enqueue(text, priority="asap")
+    elif not queue_steering(chat_id, user_id, text):
+        return False
+    _interjection_budget[key] = (count + 1, chars + len(text))
+    return True
+
+
+def clear_all_locks() -> None:
+    """Drop the conversation-lock registry (session-wide cleanup)."""
+    _conversation_locks.clear()

--- a/tests/test_agent_safety.py
+++ b/tests/test_agent_safety.py
@@ -10,6 +10,7 @@ disable-able; capability assembly must follow the config switches.
 from __future__ import annotations
 
 from datetime import timedelta
+from types import SimpleNamespace
 
 import pytest
 from pydantic_ai_harness.guardrails import ToolResultInfo
@@ -153,6 +154,7 @@ def test_build_agent_capabilities_follows_switches(monkeypatch):
     assert kinds == {
         "ProcessHistory",
         "ModelActivityLog",
+        "SteeringInjection",
         "ClampOversizedMessages",
         "WarnNearLimits",
     }
@@ -305,3 +307,55 @@ async def test_clear_all_spills_removes_every_session(tmp_path, monkeypatch):
                 await store.read("k")
         finally:
             safety.reset_spill_session(token)
+
+
+async def test_steering_injection_folds_into_next_request():
+    """Queued interjections are appended to the very next model request -
+    the mid-turn injection point pydantic-ai re-reads before every call."""
+    from pydantic_ai import Agent
+    from pydantic_ai.models.test import TestModel
+
+    from kmua.plugins.agent import state
+    from kmua.plugins.agent.safety import SteeringInjection
+
+    state._steering_messages.clear()
+    try:
+        agent = Agent(
+            TestModel(),
+            capabilities=[SteeringInjection()],
+        )
+        state.queue_steering(-100, 1, "别下载了, 直接分析文本")
+        result = await agent.run(
+            "处理这个文件",
+            deps=SimpleNamespace(chat_id=-100, user_id=1),
+        )
+        joined = " ".join(
+            str(part.content)
+            for msg in result.all_messages()
+            for part in msg.parts
+            if part.part_kind == "user-prompt"
+        )
+        assert "别下载了, 直接分析文本" in joined
+        assert state.drain_steering(-100, 1) == []
+    finally:
+        state._steering_messages.clear()
+
+
+async def test_steering_injection_empty_queue_passthrough():
+    from pydantic_ai import Agent
+    from pydantic_ai.models.test import TestModel
+
+    from kmua.plugins.agent.safety import SteeringInjection
+
+    agent = Agent(
+        TestModel(custom_output_text="ok"),
+        capabilities=[SteeringInjection()],
+    )
+    result = await agent.run("hi", deps=SimpleNamespace(chat_id=-100, user_id=1))
+    texts = [
+        str(part.content)
+        for msg in result.all_messages()
+        for part in msg.parts
+        if part.part_kind == "user-prompt"
+    ]
+    assert texts == ["hi"]

--- a/tests/test_history_compaction.py
+++ b/tests/test_history_compaction.py
@@ -313,7 +313,6 @@ async def test_clear_prefix_helpers():
     await cache.set("message_history_with_agent:1:1", b"a")
     await cache.set("message_history_with_agent:1:2", b"b")
     await cache.set("other:key", b"c")
-    store._data["agent_waiting:1"] = True
     store._data["agent_ask_state:1:1"] = {"options": []}
     store._data["unrelated"] = 1
 
@@ -321,7 +320,237 @@ async def test_clear_prefix_helpers():
     assert await cache.get("message_history_with_agent:1:1") is None
     assert await cache.get("other:key") == b"c"
 
-    assert agent_mod._clear_memstore_prefix("agent_") == 2
-    assert "agent_waiting:1" not in store._data
+    assert agent_mod._clear_memstore_prefix("agent_") == 1
     assert "agent_ask_state:1:1" not in store._data
     assert "unrelated" in store._data
+
+
+async def test_conversation_locks_are_per_conversation():
+    """Turn ownership is keyed by (chat, user): a run in chat A must not
+    block messages in chat B."""
+    from kmua.plugins.agent import state
+
+    state._conversation_locks.clear()
+    try:
+        lock_a = state.get_conversation_lock(-100, 1)
+        assert not state.is_running(-100, 1)
+        await lock_a.acquire()
+        assert state.is_running(-100, 1)
+        assert not state.is_running(-200, 1)  # same user, other chat: free
+        assert not state.is_running(-100, 2)  # other user, same chat: free
+        lock_a.release()
+        assert not state.is_running(-100, 1)
+    finally:
+        state._conversation_locks.clear()
+
+
+def test_steering_queue_is_bounded():
+    """An over-limit steering queue drops new messages instead of growing."""
+    from kmua.plugins.agent import state
+
+    state._steering_messages.clear()
+    try:
+        state.queue_steering(-100, 1, "a" * 100)
+        # Exceed the char cap with the second message.
+        state.queue_steering(-100, 1, "b" * 8000)
+        assert state.drain_steering(-100, 1) == ["a" * 100]
+    finally:
+        state._steering_messages.clear()
+
+
+def test_clear_steering_drops_queued_messages():
+    """History cleanup must also drop queued interjections so deleted
+    content is never re-injected."""
+    from kmua.plugins.agent import state
+
+    state._steering_messages.clear()
+    try:
+        state.queue_steering(-100, 1, "queued")
+        state.queue_steering(-200, 1, "other chat")
+        assert state.clear_steering(-100, 1) is None or True
+        assert state.drain_steering(-100, 1) == []
+        assert state.drain_steering(-200, 1) == ["other chat"]
+        state.queue_steering(-100, 1, "again")
+        assert state.clear_all_steering() == 1
+        assert state.drain_steering(-100, 1) == []
+    finally:
+        state._steering_messages.clear()
+
+
+def test_steering_queue_round_trip():
+    """Interjections queue per conversation and drain in order."""
+    from kmua.plugins.agent import state
+
+    state._steering_messages.clear()
+    try:
+        state.queue_steering(-100, 1, "first")
+        state.queue_steering(-100, 1, "second")
+        state.queue_steering(-100, 2, "other user")
+        assert state.drain_steering(-100, 1) == ["first", "second"]
+        assert state.drain_steering(-100, 1) == []
+        assert state.drain_steering(-100, 2) == ["other user"]
+    finally:
+        state._steering_messages.clear()
+
+
+def test_steering_queue_empty_drain():
+    from kmua.plugins.agent import state
+
+    state._steering_messages.clear()
+    try:
+        assert state.drain_steering(-100, 9) == []
+    finally:
+        state._steering_messages.clear()
+
+
+async def test_interjection_enqueues_into_active_run():
+    """A live AgentRun receives the interjection immediately (no hook
+    round-trip, no extra model request); the steering queue is only the
+    fallback while no run is registered."""
+    from kmua.plugins.agent import agent as agent_mod
+    from kmua.plugins.agent import state
+
+    state._active_runs.clear()
+    state._steering_messages.clear()
+    try:
+        enqueued = []
+
+        class FakeRun:
+            result = None  # run in flight
+
+            def enqueue(self, *content, priority="asap"):
+                enqueued.append((content, priority))
+
+        state.register_active_run(-100, 1, FakeRun())
+        msg = SimpleNamespace(text="别那样做", caption=None)
+        await agent_mod._queue_interjection(msg, -100, 1)  # type: ignore[arg-type]
+        assert enqueued == [(("别那样做",), "asap")]
+        assert state.drain_steering(-100, 1) == []
+
+        # No active run: falls back to the steering queue.
+        state.unregister_active_run(-100, 1)
+        await agent_mod._queue_interjection(msg, -100, 1)  # type: ignore[arg-type]
+        assert state.drain_steering(-100, 1) == ["别那样做"]
+    finally:
+        state._active_runs.clear()
+        state._steering_messages.clear()
+
+
+async def test_interjection_media_message_gets_placeholder():
+    from kmua.plugins.agent import agent as agent_mod
+    from kmua.plugins.agent import state
+
+    state._active_runs.clear()
+    state._steering_messages.clear()
+    try:
+        msg = SimpleNamespace(text=None, caption=None)
+        await agent_mod._queue_interjection(msg, -100, 1)  # type: ignore[arg-type]
+        queued = state.drain_steering(-100, 1)
+        assert queued == ["[用户发送了一条消息, 内容为媒体]"]
+    finally:
+        state._active_runs.clear()
+        state._steering_messages.clear()
+
+
+async def test_enqueue_interjection_budget_and_live_run():
+    """Direct live-run enqueues share the steering caps; the budget resets
+    when the run ends."""
+    from kmua.plugins.agent import state
+
+    state._active_runs.clear()
+    state._steering_messages.clear()
+    state._interjection_budget.clear()
+    try:
+        enqueued = []
+
+        class FakeRun:
+            result = None  # run in flight
+
+            def enqueue(self, *content, priority="asap"):
+                enqueued.append(content)
+
+        state.register_active_run(-100, 1, FakeRun())
+        for i in range(state._MAX_STEERING_MESSAGES):
+            assert state.enqueue_interjection(-100, 1, f"msg{i}") is True
+        # Budget exhausted: rejected, nothing enqueued.
+        assert state.enqueue_interjection(-100, 1, "overflow") is False
+        assert len(enqueued) == state._MAX_STEERING_MESSAGES
+
+        # Run ended: budget resets.
+        state.unregister_active_run(-100, 1)
+        assert state.enqueue_interjection(-100, 1, "after run") is True
+        assert state.drain_steering(-100, 1) == ["after run"]
+    finally:
+        state._active_runs.clear()
+        state._steering_messages.clear()
+        state._interjection_budget.clear()
+
+
+def test_conversation_lock_pruning_bounds_registry():
+    """Unlocked locks are pruned once the registry exceeds its bound."""
+    from kmua.plugins.agent import state
+
+    state._conversation_locks.clear()
+    try:
+        for i in range(state._MAX_CONVERSATION_LOCKS):
+            state.get_conversation_lock(1000 + i, 1)
+        assert len(state._conversation_locks) == state._MAX_CONVERSATION_LOCKS
+        # One more conversation: the unlocked locks are pruned first.
+        state.get_conversation_lock(9999, 1)
+        assert len(state._conversation_locks) <= 2
+    finally:
+        state._conversation_locks.clear()
+
+
+async def test_enqueue_skips_ended_run_and_charges_on_success():
+    """A run whose graph ended (result populated) must not accept enqueues:
+    the message falls into the fallback queue instead of being stranded.
+    The budget is charged only when the delivery actually succeeded."""
+    from kmua.plugins.agent import state
+
+    state._active_runs.clear()
+    state._steering_messages.clear()
+    state._interjection_budget.clear()
+    try:
+        enqueued = []
+
+        class EndedRun:
+            result = object()  # graph already finished
+
+            def enqueue(self, *content, priority="asap"):
+                enqueued.append(content)
+
+        state.register_active_run(-100, 1, EndedRun())
+        assert state.enqueue_interjection(-100, 1, "late") is True
+        assert enqueued == []  # nothing went into the ended run
+        assert state.drain_steering(-100, 1) == ["late"]
+        # Budget was charged once for the successful fallback delivery.
+        assert state._interjection_budget[(-100, 1)] == (1, 4)
+
+        # Fallback queue full: rejected without charging the budget.
+        state._interjection_budget[(-100, 1)] = (
+            state._MAX_STEERING_MESSAGES,
+            0,
+        )
+        assert state.enqueue_interjection(-100, 1, "x") is False
+    finally:
+        state._active_runs.clear()
+        state._steering_messages.clear()
+        state._interjection_budget.clear()
+
+
+async def test_clear_steering_resets_budget():
+    from kmua.plugins.agent import state
+
+    state._steering_messages.clear()
+    state._interjection_budget.clear()
+    try:
+        state._interjection_budget[(-100, 1)] = (5, 100)
+        state.clear_steering(-100, 1)
+        assert (-100, 1) not in state._interjection_budget
+        state._interjection_budget[(-100, 1)] = (5, 100)
+        assert state.clear_all_steering() == 0
+        assert state._interjection_budget == {}
+    finally:
+        state._steering_messages.clear()
+        state._interjection_budget.clear()


### PR DESCRIPTION
Mid-turn messages enqueue straight into the live AgentRun's pending-message queue, so the next model request - or the end-of-run redirect - carries them within the same run: quotas, timeout and usage stay continuous. Turn ownership is a per-conversation lock covering wake, ask, guest and follow-up; interjections are budget-capped, session cleanup cancels active runs, and the runner drives nodes via next() so pending messages are never stranded.